### PR TITLE
new h5pyd tests

### DIFF
--- a/client/h5pyd/h5pyd/_hl/dataset.py
+++ b/client/h5pyd/h5pyd/_hl/dataset.py
@@ -150,10 +150,11 @@ def make_new_dset(parent, shape=None, dtype=None, data=None,
     dset_id = DatasetID(parent, body)
 
     if data is not None:
-        pass
-        # todo
-        #dset_id.write(h5s.ALL, h5s.ALL, data)
-
+        req = "/datasets/" + dset_id.uuid + "/value"
+        body = {}
+        body['value'] = data.tolist()
+        parent.PUT(req, body=body)
+        
     return dset_id
    
     

--- a/client/h5pyd/test/createdataset.py
+++ b/client/h5pyd/test/createdataset.py
@@ -11,6 +11,7 @@
 ##############################################################################
 import sys
 sys.path.append('..')
+import numpy as np
 import h5pyd
 
 f = h5pyd.File("createdataset.client_test.hdfgroup.org", "w", endpoint="http://127.0.0.1:5000")
@@ -36,5 +37,11 @@ print "values:", dset[...]
 print "write selection..."
 dset[2:5] = [20,30,40]
 print "values:", dset[...]
+
+
+data = np.arange(13).astype('f')
+print "input data:", data[...]
+dset = f.create_dataset('x', data=data)  
+print "output data:", dset[...]
 
  

--- a/client/h5pyd/test/test1.py
+++ b/client/h5pyd/test/test1.py
@@ -52,4 +52,5 @@ print "attr keys:", dset111.attrs.keys()
 
 for attr in dset111.attrs:
     print 'name:', attr
+      
     

--- a/client/h5pyd/test/test_file.py
+++ b/client/h5pyd/test/test_file.py
@@ -1,0 +1,105 @@
+##############################################################################
+# Copyright by The HDF Group.                                                #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of H5Serv (HDF5 REST Server) Service, Libraries and      #
+# Utilities.  The full HDF5 REST Server copyright notice, including          #
+# terms governing use, modification, and redistribution, is contained in     #
+# the file COPYING, which can be found at the root of the source code        #
+# distribution tree.  If you do not have access to this file, you may        #
+# request a copy from help@hdfgroup.org.                                     #
+##############################################################################
+import h5pyd as h5py
+from common import ut, TestCase
+
+        
+class TestFile(TestCase):
+    
+    def test_version(self):
+        version = h5py.version.version
+        # should be of form "n.n.n"
+        self.assertEqual(len(version), 5)
+        self.assertEqual(version[1], '.')
+        self.assertEqual(version[3], '.')
+         
+        
+    def test_create(self):
+        filename = "new_file." + self.base_domain
+         
+        f = h5py.File(filename, 'w')
+        self.assertEqual(f.filename, filename)
+        self.assertEqual(f.name, "/")
+        self.assertTrue(f.id.id is not None)
+        self.assertEqual(len(f.keys()), 0)
+        self.assertEqual(f.mode, 'r+')
+        self.assertTrue('/' in f)      
+        r = f['/']
+        self.assertTrue(isinstance(r, h5py.Group))
+        self.assertEqual(len(f.attrs.keys()), 0)
+        f.close()
+        self.assertEqual(f.id.id, 0)
+        
+        
+        # re-open as read-write
+        f = h5py.File(filename, 'r+')
+        self.assertTrue(f.id.id is not None)
+        self.assertEqual(f.mode, 'r+')
+        self.assertEqual(len(f.keys()), 0)
+        f.create_group("subgrp")
+        self.assertEqual(len(f.keys()), 1)
+        f.close()
+        self.assertEqual(f.id.id, 0)
+        
+        # re-open as read-only
+        f = h5py.File(filename, 'r')
+        self.assertEqual(f.filename, filename)
+        self.assertEqual(f.name, "/")
+        self.assertTrue(f.id.id is not None)
+        self.assertEqual(len(f.keys()), 1)
+        self.assertEqual(f.mode, 'r')
+        self.assertTrue('/' in f)      
+        r = f['/']
+        self.assertTrue(isinstance(r, h5py.Group))
+        self.assertEqual(len(f.attrs.keys()), 0)
+        
+        try:
+            f.create_group("another_subgrp")
+            self.assertTrue(False)  # expect exception
+        except ValueError:
+            pass
+        self.assertEqual(len(f.keys()), 1)
+        
+        f.close()
+        self.assertEqual(f.id.id, 0)
+        
+        # open in truncate mode
+        f = h5py.File(filename, 'w')
+        self.assertEqual(f.filename, filename)
+        self.assertEqual(f.name, "/")
+        self.assertTrue(f.id.id is not None)
+        self.assertEqual(len(f.keys()), 0)
+        self.assertEqual(f.mode, 'r+')
+        self.assertTrue('/' in f)      
+        r = f['/']
+        self.assertTrue(isinstance(r, h5py.Group))
+        self.assertEqual(len(f.attrs.keys()), 0)
+        
+        f.close()
+        self.assertEqual(f.id.id, 0)
+           
+        # verify open of non-existent file throws exception
+        try:
+            f = h5py.File("no_file_here." + self.base_domain, 'r')
+            self.assertTrue(False) #expect exception
+        except IOError:
+            pass
+        
+
+         
+        
+if __name__ == '__main__':
+    ut.main()
+
+
+     
+    

--- a/client/h5pyd/test/test_group.py
+++ b/client/h5pyd/test/test_group.py
@@ -1,0 +1,95 @@
+##############################################################################
+# Copyright by The HDF Group.                                                #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of H5Serv (HDF5 REST Server) Service, Libraries and      #
+# Utilities.  The full HDF5 REST Server copyright notice, including          #
+# terms governing use, modification, and redistribution, is contained in     #
+# the file COPYING, which can be found at the root of the source code        #
+# distribution tree.  If you do not have access to this file, you may        #
+# request a copy from help@hdfgroup.org.                                     #
+##############################################################################
+import h5pyd as h5py
+from common import ut, TestCase
+
+        
+class TestGroup(TestCase):
+    
+        
+    def test_create(self):
+        filename = "new_group." + self.base_domain
+        f = h5py.File(filename, 'w')
+        self.assertTrue(f.id.id is not None)
+        self.assertTrue('/' in f)      
+        r = f['/']
+        
+        self.assertEqual(len(r), 0)
+        self.assertTrue(isinstance(r, h5py.Group))
+        self.assertTrue(r.name, '/')
+        self.assertEqual(len(r.attrs.keys()), 0)
+        
+        self.assertFalse('g1' in r)
+         
+        r.create_group('g1')
+        self.assertTrue('g1' in r)
+        r.create_group('g2')
+        self.assertEqual(len(r), 2)
+        keys = []
+        # iterate through keys
+        for k in r:
+            keys.append(k)
+            
+        self.assertEqual(len(keys), 2)
+        self.assertTrue('g1' in keys)
+        self.assertTrue('g2' in keys)
+        
+        self.assertTrue('g1' in r)
+        self.assertTrue('/g1' in r)
+        g1 = r.get('/g1')
+        self.assertTrue(g1.id.id)
+        self.assertEqual(g1.name, '/g1')
+        
+        g1_class = r.get('g1', getclass=True)
+        self.assertEqual(g1_class, h5py.Group)
+        
+        # try creating a group that already exists
+        try:
+            r.create_group('g1')
+            self.assertTrue(False)
+        except ValueError:
+            pass # expected
+            
+        r.create_group('g3')
+        self.assertEqual(len(r), 3)
+        del r['g3']
+        self.assertEqual(len(r), 2)
+        
+        r.require_group('g4')
+        self.assertEqual(len(r), 3)
+        r.require_group('g2') 
+        self.assertEqual(len(r), 3)
+        
+        g1_1 = r.create_group("g1/g1.1")
+        self.assertEqual(len(r), 3)
+        self.assertEqual(len(g1), 1)
+        self.assertEqual(len(g1_1), 0)
+        
+        # create a link
+        r['g1.1'] = g1_1
+        self.assertEqual(len(r), 4)
+        
+        #todo - test visit
+        
+        
+        f.close()
+        self.assertEqual(f.id.id, 0)
+        
+        
+         
+        
+if __name__ == '__main__':
+    ut.main()
+
+
+     
+    

--- a/docs/DatasetOps/PUT_Value.rst
+++ b/docs/DatasetOps/PUT_Value.rst
@@ -13,7 +13,7 @@ Syntax
 ------
 .. code-block:: http
 
-    PUT /datasets/<id> HTTP/1.1
+    PUT /datasets/<id>/value HTTP/1.1
     Host: DOMAIN
     Authorization: <authorization_string>
     


### PR DESCRIPTION
Joe,
  If you have time, take a look at these tests I added for the h5pyd package.  This is a package that is a h5py compatible front-end to the rest api.  I've been switching the import line from "import h5pyd as h5py" to "import h5py as h5py" to verify the test work for both h5serv and h5py.
  Let me know if you have comments regarding methodology are tests I should add.
  I'll be adding test files for attributes, datasets, etc. 