### PR TITLE
Use module-level logging

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -31,43 +31,41 @@ from hdf5db import Hdf5db
 import hdf5dtype
 
 from timeUtil import unixTimeToUTC
-from fileUtil import getFilePath,  makeDirs, verifyFile
+from fileUtil import getFilePath, makeDirs, verifyFile
 from tocUtil import isTocFilePath, getTocFilePath
 from httpErrorUtil import errNoToHttpStatus
 from passwordUtil import getUserId, getUserName, validateUserPassword
 
-    
+logger = logging.getLogger('h5serv')
+
+
 class DefaultHandler(RequestHandler):
     def put(self):
-        log = logging.getLogger("h5serv")
-        log.warning("got default PUT request")
-        log.info('remote_ip: ' + self.request.remote_ip)
-        log.warning(self.request)
-        raise HTTPError(400, reason="No route matches") 
-        
+        logger.warning("got default PUT request")
+        logger.info('remote_ip: ' + self.request.remote_ip)
+        logger.warning(self.request)
+        raise HTTPError(400, reason="No route matches")
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.warning("got default GET request")
-        log.info('remote_ip: ' + self.request.remote_ip)
-        log.warning(self.request)
-        raise HTTPError(400, reason="No route matches") 
-        
+        logger.warning("got default GET request")
+        logger.info('remote_ip: ' + self.request.remote_ip)
+        logger.warning(self.request)
+        raise HTTPError(400, reason="No route matches")
+
     def post(self):
-        log = logging.getLogger("h5serv") 
-        log.warning("got default POST request")
-        log.info('remote_ip: ' + self.request.remote_ip)
-        log.warning(self.request)
-        raise HTTPError(400, reason="No route matches") 
-        
+        logger.warning("got default POST request")
+        logger.info('remote_ip: ' + self.request.remote_ip)
+        logger.warning(self.request)
+        raise HTTPError(400, reason="No route matches")
+
     def delete(self):
-        log = logging.getLogger("h5serv")
-        log.warning("got default DELETE request")
-        log.info('remote_ip: ' + self.request.remote_ip)
-        log.warning(self.request)
-        raise HTTPError(400, reason="No route matches") 
-        
-class BaseHandler(tornado.web.RequestHandler):
-    
+        logger.warning("got default DELETE request")
+        logger.info('remote_ip: ' + self.request.remote_ip)
+        logger.warning(self.request)
+        raise HTTPError(400, reason="No route matches")
+
+
+class BaseHandler(RequestHandler):
     """
     Enable CORS
     """
@@ -75,7 +73,7 @@ class BaseHandler(tornado.web.RequestHandler):
         cors_domain = config.get('cors_domain')
         if cors_domain:
             self.set_header('Access-Control-Allow-Origin', cors_domain)
-        
+
     """
     Override of Tornado get_current_user
     """
@@ -86,14 +84,14 @@ class BaseHandler(tornado.web.RequestHandler):
         if scheme.lower() == 'basic':
             user, _, pswd= base64.decodestring(token).partition(':')
         if user and pswd:
-            validateUserPassword(user, pswd)  # throws exception if passwd is not valid 
+            validateUserPassword(user, pswd)  # throws exception if passwd is not valid
             self.userid = getUserId(user)
             return self.userid
-        else: 
+        else:
             self.userid = -1
             return None
-            
-            
+
+
     """
     Verify ACL for given action.
       Raise exception if not authorized
@@ -101,28 +99,27 @@ class BaseHandler(tornado.web.RequestHandler):
     def verifyAcl(self, acl, action):
         if acl[action]:
             return
-        if self.userid <= 0: 
+        if self.userid <= 0:
             self.set_status(401)
             self.set_header('WWW-Authenticate', 'basic realm="h5serv"')
             raise HTTPError(401, "Unauthorized")
             # raise HTTPError(401, message="provide  password")
         # validated user, but doesn't have access
-        log = logging.getLogger("h5serv")
-        log.info("unauthorized access for userid: " + str(self.userid))
-        raise HTTPError(403, "Access is not permitted")           
-            
+        logger.info("unauthorized access for userid: " + str(self.userid))
+        raise HTTPError(403, "Access is not permitted")
+
     """
     Helper method - return domain auth based on either query param
     or host header
-    """  
+    """
     def getDomain(self):
         domain = self.get_query_argument("host", default=None)
         if not domain:
             domain = self.request.host
         return domain
-    
+
     """
-    Helper method - return request uuid from request URI  
+    Helper method - return request uuid from request URI
     URI' are of the form:
         /groups/<uuid>/xxx
         /datasets/<uuid>/xxx
@@ -131,8 +128,7 @@ class BaseHandler(tornado.web.RequestHandler):
     Throw 500 error is the URI is not in the above form
     """
     def getRequestId(self):
-        log = logging.getLogger("h5serv")
-        
+
         uri = self.request.uri
         if uri.startswith('/groups/'):
             uri = uri[len('/groups/'):]  # get stuff after /groups/
@@ -141,38 +137,37 @@ class BaseHandler(tornado.web.RequestHandler):
         elif uri.startswith('/datatypes/'):
             uri = uri[len('/datatypes/'):]  # get stuff after /datatypes/
         else:
-            
+
             msg = "unexpected uri: " + uri
-            log.error(msg)
-            raise HTTPError(500, reason=msg) 
-            
+            logger.error(msg)
+            raise HTTPError(500, reason=msg)
+
             return None
         npos = uri.find('/')
         if npos < 0:
             uuid = uri
         elif npos == 0:
             msg = "Bad Request: uri is invalid"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         else:
             uuid = uri[:npos]
-         
-        log.info('got uuid: [' + uuid + ']')
-    
+
+        logger.info('got uuid: [' + uuid + ']')
+
         return uuid
-        
+
 class LinkCollectionHandler(BaseHandler):
-                           
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('LinkCollectionHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']') 
-        log.info('remote_ip: ' + self.request.remote_ip)     
-        self.get_current_user() 
-        
+        logger.info('LinkCollectionHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
+        self.get_current_user()
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
         filePath = getFilePath(domain)
-        
+
         # Get optional query parameters
         limit = self.get_query_argument("Limit", 0)
         if type(limit) is not int:
@@ -180,12 +175,12 @@ class LinkCollectionHandler(BaseHandler):
                 limit = int(limit)
             except ValueError:
                 msg = "Bad Request: Expected into type for limit"
-                log.info(msg)
-                raise HTTPError(400, reason=msg) 
+                logger.info(msg)
+                raise HTTPError(400, reason=msg)
         marker = self.get_query_argument("Marker", None)
-                
+
         response = { }
-        
+
         verifyFile(filePath)
         items = None
         rootUUID = None
@@ -195,12 +190,12 @@ class LinkCollectionHandler(BaseHandler):
                 current_user_acl = db.getAcl(reqUuid, self.userid)
                 self.verifyAcl(current_user_acl, 'read')  # throws exception is unauthorized
                 items = db.getLinkItems(reqUuid, marker=marker, limit=limit)
-                
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                             
+            raise HTTPError(status, reason=e.strerror)
+
         # got everything we need, put together the response
         links = []
         hrefs = []
@@ -213,7 +208,7 @@ class LinkCollectionHandler(BaseHandler):
             link_item = {}
             link_item['class'] = item['class']
             link_item['title'] = item['title']
-            link_item['href'] = item['href'] = href + 'groups/' + reqUuid + '/links/' + item['title'] + hostQuery 
+            link_item['href'] = item['href'] = href + 'groups/' + reqUuid + '/links/' + item['title'] + hostQuery
             if item['class'] == 'H5L_TYPE_HARD':
                 link_item['id'] = item['id']
                 link_item['collection'] = item['collection']
@@ -235,25 +230,24 @@ class LinkCollectionHandler(BaseHandler):
                         target += '/'
                     else:
                         target += '/#h5path(' + link_item['h5path'] + ')'
-                    target += targetHostQuery 
+                    target += targetHostQuery
                     link_item['target'] = target
-               
+
             links.append(link_item)
-             
+
         response['links'] = links
-        
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery }) 
-        hrefs.append({'rel': 'owner', 'href': href + 'groups/' + reqUuid + hostQuery})  
-        response['hrefs'] = hrefs      
+
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery })
+        hrefs.append({'rel': 'owner', 'href': href + 'groups/' + reqUuid + hostQuery})
+        response['hrefs'] = hrefs
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-    
-        
+
+
 class LinkHandler(BaseHandler):
-        
+
     def getName(self, uri):
-        log = logging.getLogger("h5serv")
         # helper method
         # uri should be in the form: /group/<uuid>/links/<name>
         # this method returns name
@@ -261,38 +255,37 @@ class LinkHandler(BaseHandler):
         if npos < 0:
             # shouldn't be possible to get here
             msg = "Internal Server Error: Unexpected uri"
-            log.error(msg)
+            logger.error(msg)
             raise HTTPError(500, reason=msg)
         if npos+len('/links/') >= len(uri):
             # no name specified
             msg = "Bad Request: no name specified"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         linkName = uri[npos+len('/links/'):]
         if linkName.find('/') >= 0:
             # can't have '/' in link name
             msg = "Bad Request: invalid linkname, '/' not allowed"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         npos = linkName.rfind('?')
         if npos >= 0:
             # trim off the query params
             linkName = linkName[:npos]
         return linkName
-        
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('LinkHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')  
-        log.info('remote_ip: ' + self.request.remote_ip)  
-        self.get_current_user()   
-        
+        logger.info('LinkHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
+        self.get_current_user()
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         linkName = self.getName(self.request.uri)
-        
+
         response = { }
-        
+
         verifyFile(filePath)
         rootUUID = None
         try:
@@ -302,36 +295,36 @@ class LinkHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 item = db.getLinkItemByUuid(reqUuid, linkName)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
             raise HTTPError(status, reason=e.strerror)
-            
+
         response['lastModified'] = unixTimeToUTC(item['mtime'])
         response['created'] = unixTimeToUTC(item['ctime'])
         for key in ('mtime', 'ctime', 'href'):
             if key in item:
                 del item[key]
-                
+
         # replace 'file' key by 'h5domain' if present
         if 'file' in item:
             h5domain = item['file']
             del item['file']
             item['h5domain'] = h5domain
-             
+
         response['link'] = item
-        
-         
-        hrefs = []     
+
+
+        hrefs = []
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
-        hrefs.append({'rel': 'self',       'href': href + 'groups/' + reqUuid + 
+        hrefs.append({'rel': 'self',       'href': href + 'groups/' + reqUuid +
             '/links/' + url_escape(linkName) + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery }) 
-        hrefs.append({'rel': 'owner', 'href': href + 'groups/' + reqUuid + hostQuery})  
-        
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery })
+        hrefs.append({'rel': 'owner', 'href': href + 'groups/' + reqUuid + hostQuery})
+
         target = None
         if item['class'] == 'H5L_TYPE_HARD':
             target = href + item['collection'] + '/' + item['id'] + hostQuery
@@ -350,72 +343,71 @@ class LinkHandler(BaseHandler):
                     target += '/'
                 else:
                     target += '/#h5path(' + item['h5path'] + ')'
-                target += targetHostQuery 
-        
+                target += targetHostQuery
+
         if target:
             hrefs.append({'rel': 'target', 'href': target})
 
-        response['hrefs'] = hrefs      
+        response['hrefs'] = hrefs
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-    
+
     def put(self):
-        log = logging.getLogger("h5serv")
-        log.info('LinkHandler.put host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
-        self.get_current_user()  
+        logger.info('LinkHandler.put host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
+        self.get_current_user()
         # put - create a new link
         # patterns are:
-        # PUT /groups/<id>/links/<name> {id: <id> } 
-        # PUT /groups/<id>/links/<name> {h5path: <path> } 
+        # PUT /groups/<id>/links/<name> {id: <id> }
+        # PUT /groups/<id>/links/<name> {h5path: <path> }
         # PUT /groups/<id>/links/<name> {h5path: <path>, h5domain: <href> }
         reqUuid = self.getRequestId()
-        
+
         linkName = url_unescape(self.getName(self.request.uri))
-        
+
         body = None
         try:
             body = json.loads(self.request.body)
         except ValueError as e:
             msg = "JSON Parser Error: " + e.message
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg )
-        
+
         childUuid = None
         h5path = None
         h5domain = None
         filename = None   # fake filename
-         
+
         if "id" in body:
             childUuid = body["id"]
             if childUuid == None or len(childUuid) == 0:
                 msg = "Bad Request: id not specified"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
         elif "h5path" in body:
             # todo
             h5path = body["h5path"]
-            if h5path == None or len(h5path) == 0:              
+            if h5path == None or len(h5path) == 0:
                 raise HTTPError(400)
-             
-            # if h5domain is present, this will be an external link     
+
+            # if h5domain is present, this will be an external link
             if "h5domain" in body:
                 h5domain = body["h5domain"]
-                    
-        else: 
+
+        else:
             msg = "Bad request: put syntax: [" + self.request.body + "]"
-            log.info(msg)
-            raise HTTPError(400, reasoln=msg)                      
-        
+            logger.info(msg)
+            raise HTTPError(400, reasoln=msg)
+
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         if isTocFilePath(filePath):
             msg = "Forbidden: links can not be directly created in TOC domain"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(403, reason=msg)
-        
+
         response = { }
-        
+
         verifyFile(filePath)
         rootUUID = None
         try:
@@ -429,39 +421,38 @@ class LinkHandler(BaseHandler):
                     db.createExternalLink(reqUuid, h5domain, h5path, linkName)
                 elif h5path:
                     db.createSoftLink(reqUuid, h5path, linkName)
-                
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror)   
-            
-        hrefs = []     
+            raise HTTPError(status, reason=e.strerror)
+
+        hrefs = []
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
-        hrefs.append({'rel': 'self',       'href': href + 'groups/' + reqUuid + 
+        hrefs.append({'rel': 'self',       'href': href + 'groups/' + reqUuid +
             '/links/' + url_escape(linkName) + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
-        hrefs.append({'rel': 'owner', 'href': href + 'groups/' + reqUuid + hostQuery})  
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
+        hrefs.append({'rel': 'owner', 'href': href + 'groups/' + reqUuid + hostQuery})
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-        self.set_status(201) 
-        
-    def delete(self): 
-        log = logging.getLogger("h5serv")
-        log.info('LinkHandler.delete ' + self.request.host)   
-        log.info('remote_ip: ' + self.request.remote_ip)
-        self.get_current_user()  
+        self.set_status(201)
+
+    def delete(self):
+        logger.info('LinkHandler.delete ' + self.request.host)
+        logger.info('remote_ip: ' + self.request.remote_ip)
+        self.get_current_user()
         reqUuid = self.getRequestId()
-        
+
         linkName = self.getName(self.request.uri)
-        
-        log.info( " delete link  name[: " + linkName + "] parentUuid: " + reqUuid)
-           
+
+        logger.info( " delete link  name[: " + linkName + "] parentUuid: " + reqUuid)
+
         domain = self.getDomain()
         response = { }
         rootUUID = None
@@ -469,7 +460,7 @@ class LinkHandler(BaseHandler):
         verifyFile(filePath, True)
         if isTocFilePath(filePath):
             msg = "Forbidden: links can not be directly modified in TOC domain"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(403, reason=msg)
         try:
             with Hdf5db(filePath, app_logger=log) as db:
@@ -478,61 +469,59 @@ class LinkHandler(BaseHandler):
                 self.verifyAcl(acl, 'delete')  # throws exception is unauthorized
                 db.unlinkItem(reqUuid, linkName)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-            
-        hrefs = []     
+            raise HTTPError(status, reason=e.strerror)
+
+        hrefs = []
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
-        hrefs.append({'rel': 'owner', 'href': href + 'groups/' + reqUuid + hostQuery})  
-        
-        response['hrefs'] = hrefs      
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
+        hrefs.append({'rel': 'owner', 'href': href + 'groups/' + reqUuid + hostQuery})
+
+        response['hrefs'] = hrefs
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
 
 class AclHandler(BaseHandler):
-        
+
     def getRequestCollectionName(self):
-        log = logging.getLogger("h5serv")
-        # request is in the form /(datasets|groups|datatypes)/<id>/acls(/<username>), 
+        # request is in the form /(datasets|groups|datatypes)/<id>/acls(/<username>),
         # or /acls(/<username>) for domain acl
         # return datasets | groups | datatypes
         uri = self.request.uri
-        
+
         npos = uri.find('/')
         if npos < 0:
-            log.info("bad uri")
-            raise HTTPError(400)  
+            logger.info("bad uri")
+            raise HTTPError(400)
         if uri.startswith('/acls/'):
             # domain request - return group collection
             return 'groups'
-            
+
         uri = uri[(npos+1):]
-        
+
         npos = uri.find('/')  # second '/'
         if npos < 0:
             # uri is "/acls"
             return "groups"
         col_name = uri[:npos]
-         
-        log.info('got collection name: [' + col_name + ']')
+
+        logger.info('got collection name: [' + col_name + ']')
         if col_name not in ('datasets', 'groups', 'datatypes'):
             msg = "Internal Server Error: collection name unexpected"
-            log.error(msg)
+            logger.error(msg)
             raise HTTPError(500, reason=msg)   # shouldn't get routed here in this case
-    
+
         return col_name
-     
-        
+
+
     def getName(self):
-        log = logging.getLogger("h5serv")
         uri = self.request.uri
-         
+
         if uri == '/acls':
             return None  # default domain acl
         # helper method
@@ -542,30 +531,29 @@ class AclHandler(BaseHandler):
         if npos < 0:
             # shouldn't be possible to get here
             msg = "Internal Server Error: Unexpected uri"
-            log.error(msg)
+            logger.error(msg)
             raise HTTPError(500, reason=msg)
         if npos+len('/acls/') >= len(uri):
             # no name specified
             msg = "Bad Request: no name specified"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         userName = uri[npos+len('/acls/'):]
         if userName.find('/') >= 0:
             # can't have '/' in link name
             msg = "Bad Request: invalid linkname, '/' not allowed"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         npos = userName.rfind('?')
         if npos >= 0:
             # trim off the query params
             userName = userName[:npos]
         return userName
-    
-    """ 
+
+    """
     convertUserIdToUserName - replace userids with username
-    """   
+    """
     def convertUserIdToUserName(self, acl_in):
-        log = logging.getLogger("h5serv")
         acl_out = None
         if type(acl_in) in (list, tuple):
             # convert list to list
@@ -578,41 +566,40 @@ class AclHandler(BaseHandler):
                 if key == 'userid':
                     # convert userid to username
                     userid = acl_in['userid']
-               
+
                     user_name = '???'
                     if userid == 0:
                         user_name = 'default'
                     else:
                         user_name = getUserName(userid)
                         if user_name is None:
-                            log.warn("user not found for userid: " + str(userid))  
+                            logger.warn("user not found for userid: " + str(userid))
                     acl_out['userName'] = user_name
                 else:
                     value = acl_in[key]
                     acl_out[key] = True if value else False
         return acl_out
-        
-   
-        
+
+
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('AclHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')  
-        log.info('remote_ip: ' + self.request.remote_ip)    
-        
+        logger.info('AclHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
+
         self.get_current_user()
         req_uuid = None
         if not self.request.uri.startswith("/acls"):
             # get UUID for object unless this is a get on domain acl
             req_uuid = self.getRequestId()
-        
+
         domain = self.getDomain()
-      
+
         rootUUID = None
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         userName = self.getName()
-  
+
         col_name = self.getRequestCollectionName()
-        
+
         req_userid = None
         if userName:
             if userName == 'default':
@@ -622,9 +609,9 @@ class AclHandler(BaseHandler):
                 if req_userid is None:
                     # username not found
                     msg = "username does not exist"
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(404, reason=msg)
-        
+
         request = {}
         verifyFile(filePath)
         acl = None
@@ -636,91 +623,90 @@ class AclHandler(BaseHandler):
                     obj_uuid = req_uuid
                 else:
                     obj_uuid = rootUUID
-                    
+
                 current_user_acl = db.getAcl(obj_uuid, self.userid)
                 self.verifyAcl(current_user_acl, 'readACL')  # throws exception is unauthorized
                 if req_userid is None:
                     acl = db.getAcls(obj_uuid)
                 else:
                     acl = db.getAcl(obj_uuid, req_userid)
-                
-                
+
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
             raise HTTPError(status, reason=e.strerror)
-               
-        response = {}     
+
+        response = {}
         acl = self.convertUserIdToUserName(acl)
-         
+
         response['acls'] = acl
-        
+
         if userName is None:
             userName = ''  # for string concat in the hrefs
-             
-        hrefs = []     
+
+        hrefs = []
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
-        hrefs.append({'rel': 'self',       'href': href + col_name + '/' + obj_uuid + 
+        hrefs.append({'rel': 'self',       'href': href + col_name + '/' + obj_uuid +
             '/acl/' + url_escape(userName) + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery }) 
-        hrefs.append({'rel': 'owner', 'href': href + col_name + '/' + obj_uuid + hostQuery})  
-        
-        response['hrefs'] = hrefs      
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery })
+        hrefs.append({'rel': 'owner', 'href': href + col_name + '/' + obj_uuid + hostQuery})
+
+        response['hrefs'] = hrefs
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-              
-    
+
+
     def put(self):
-        log = logging.getLogger("h5serv")
-        log.info('AclHandler.put host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('AclHandler.put host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.current_user = self.get_current_user()
         # put - create/update an acl
         # patterns are:
-        # PUT /group/<id>/acls/<name> {'read': True, 'write': False } 
+        # PUT /group/<id>/acls/<name> {'read': True, 'write': False }
         # PUT /acls/<name> {'read'... }
-        
+
         req_uuid = None
         if not self.request.uri.startswith("/acls/"):
             req_uuid = self.getRequestId()
         col_name = self.getRequestCollectionName()
         userName = url_unescape(self.getName())
-        
+
         if userName is None or len(userName) == 0:
             msg = "Bad Request: username not provided"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
-            
+
         req_userid = None   # this is the userid of the acl we'll be updating
         # self.userid is the userid of the requestor
         if userName == 'default':
             req_userid = 0
         else:
             req_userid = getUserId(userName)
-            
+
         if req_userid is None:
             msg = "Bad Request: username not found"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
-            
-        
+
+
         body = None
         try:
             body = json.loads(self.request.body)
         except ValueError as e:
             msg = "JSON Parser Error: " + e.message
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg )
-            
+
         if 'perm' not in body:
             msg = "Bad Request: acl not found in request body"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
-            
+
         perm = body['perm']
         acl = {}
         acl['userid'] = req_userid
@@ -729,15 +715,15 @@ class AclHandler(BaseHandler):
                 acl[key] = 1 if perm[key] else 0
         if len(acl) == 1:
             msg = "Bad Request: no acl permissions found in request body"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
-                                
-        
+
+
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
-        
+        filePath = getFilePath(domain)
+
         response = { }
-        
+
         verifyFile(filePath)
         rootUUID = None
         obj_uuid = None
@@ -752,48 +738,47 @@ class AclHandler(BaseHandler):
                 self.verifyAcl(current_user_acl, 'updateACL')  # throws exception is unauthorized
                 db.setAcl(obj_uuid, acl)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror)   
-            
-        hrefs = []     
+            raise HTTPError(status, reason=e.strerror)
+
+        hrefs = []
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
-        hrefs.append({'rel': 'self',       'href': href + col_name + '/' + obj_uuid + 
+        hrefs.append({'rel': 'self',       'href': href + col_name + '/' + obj_uuid +
             '/acls/' + url_escape(userName) + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery }) 
-        hrefs.append({'rel': 'owner', 'href': href + col_name + '/' + obj_uuid + hostQuery})  
-        
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery })
+        hrefs.append({'rel': 'owner', 'href': href + col_name + '/' + obj_uuid + hostQuery})
 
-        response['hrefs'] = hrefs      
-        
+
+        response['hrefs'] = hrefs
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-        self.set_status(201) 
-        
-                                
+        self.set_status(201)
+
+
 class TypeHandler(BaseHandler):
-     
-        
+
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('TypeHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('TypeHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
-         
+
         if not reqUuid:
             msg = "Bad Request: id is not specified"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
@@ -805,19 +790,19 @@ class TypeHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 item = db.getCommittedTypeItemByUuid(reqUuid)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
+            raise HTTPError(status, reason=e.strerror)
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'datatypes/' + reqUuid + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'attributes', 'href': href + 'datatypes/' + reqUuid + '/attributes' + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery})        
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'attributes', 'href': href + 'datatypes/' + reqUuid + '/attributes' + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
         response['id'] = reqUuid
         typeItem = item['type']
         response['type'] = hdf5dtype.getTypeResponse(typeItem)
@@ -825,17 +810,16 @@ class TypeHandler(BaseHandler):
         response['lastModified'] = unixTimeToUTC(item['mtime'])
         response['attributeCount'] = item['attributeCount']
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-            
-        
-    def delete(self): 
-        log = logging.getLogger("h5serv")
-        log.info('TypeHandler.delete ' + self.request.host)   
-        log.info('remote_ip: ' + self.request.remote_ip)
+
+
+    def delete(self):
+        logger.info('TypeHandler.delete ' + self.request.host)
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         req_uuid = self.getRequestId()
         domain = self.getDomain()
         filePath = getFilePath(domain)
@@ -850,10 +834,10 @@ class TypeHandler(BaseHandler):
                 self.verifyAcl(acl, 'delete')  # throws exception is unauthorized
                 db.deleteObjectByUuid('datatype', req_uuid)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-            
+            raise HTTPError(status, reason=e.strerror)
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
@@ -862,26 +846,25 @@ class TypeHandler(BaseHandler):
         hrefs.append({'rel': 'self',  'href': href + 'datatypes' + hostQuery})
         hrefs.append({'rel': 'home',  'href': href + hostQuery})
         hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery})
-       
+
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-                
+
 class DatatypeHandler(BaseHandler):
-    
-    
+
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('DatatypeHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('DatatypeHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
@@ -893,10 +876,10 @@ class DatatypeHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 item = db.getDatasetTypeItemByUuid(reqUuid)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
+            raise HTTPError(status, reason=e.strerror)
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
@@ -906,30 +889,29 @@ class DatatypeHandler(BaseHandler):
         hrefs.append({'rel': 'owner', 'href': href + 'datasets/' + reqUuid + hostQuery})
         hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery})
         response['type'] = item['type']
-       
+
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-                
+
 class ShapeHandler(BaseHandler):
-        
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('ShapeHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('ShapeHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
         item = None
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -937,10 +919,10 @@ class ShapeHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 item = db.getDatasetItemByUuid(reqUuid)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
+            raise HTTPError(status, reason=e.strerror)
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
@@ -948,27 +930,26 @@ class ShapeHandler(BaseHandler):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',  'href': href + 'datasets/' + reqUuid + hostQuery})
         hrefs.append({'rel': 'owner', 'href': href + 'datasets/' + reqUuid + hostQuery})
-        hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery})   
+        hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery})
         shape = item['shape']
         response['shape'] = shape
         response['created'] = unixTimeToUTC(item['ctime'])
         response['lastModified'] = unixTimeToUTC(item['mtime'])
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-        
+
     def put(self):
-        log = logging.getLogger("h5serv")
-        log.info('ShapeHandler.put host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('ShapeHandler.put host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
-        reqUuid = self.getRequestId()       
+
+        reqUuid = self.getRequestId()
         domain = self.getDomain()
         filePath = getFilePath(domain)
         verifyFile(filePath, True)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
@@ -977,36 +958,36 @@ class ShapeHandler(BaseHandler):
             body = json.loads(self.request.body)
         except ValueError as e:
             msg = "JSON Parser Error: " + e.message
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg )
-        
+
         if "shape" not in body:
             msg = "Bad Request: Shape not specified"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)  # missing shape
-            
+
         shape = body["shape"]
         if type(shape) == int:
             dim1 = shape
             shape = [dim1]
-        elif type(shape) == list or type(shape) == tuple: 
+        elif type(shape) == list or type(shape) == tuple:
             pass # can use as is
         else:
             msg = "Bad Request: invalid shape argument"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
-            
+
         # validate shape
         for extent in shape:
             if type(extent) != int:
                 msg = "Bad Request: invalid shape type (expecting int)"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             if extent < 0:
                 msg = "Bad Request: invalid shape (negative extent)"
-                log.info(msg)
-                raise HTTPError(400, reason=msg) 
-        
+                logger.info(msg)
+                raise HTTPError(400, reason=msg)
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -1014,11 +995,11 @@ class ShapeHandler(BaseHandler):
                 self.verifyAcl(acl, 'update')  # throws exception is unauthorized
                 db.resizeDataset(reqUuid, shape)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                
-        log.info("resize OK")   
+            raise HTTPError(status, reason=e.strerror)
+
+        logger.info("resize OK")
         # put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
@@ -1026,16 +1007,16 @@ class ShapeHandler(BaseHandler):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',  'href': href + 'datasets/' + reqUuid + hostQuery})
         hrefs.append({'rel': 'owner', 'href': href + 'datasets/' + reqUuid + hostQuery})
-        hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery})    
+        hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery})
         response['hrefs'] = hrefs
-        
-        self.set_status(201)  # resource created    
+
+        self.set_status(201)  # resource created
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response)) 
-                
+        self.write(json_encode(response))
+
 class DatasetHandler(BaseHandler):
-     
-   
+
+
     """
     Helper method - return query options for a "reasonable" size data preview selection.
     Return None if the dataset is small enough that a preview is not needed.
@@ -1046,23 +1027,23 @@ class DatasetHandler(BaseHandler):
         dims = shape_item['dims']
         rank = len(dims)
         if rank == 0:
-            return None 
-        
+            return None
+
         count = 1
         for i in range(rank):
             count *= dims[i]
-            
+
         if count <= 100:
-            return None  
-            
+            return None
+
         select = "?select=["
-         
+
         ncols = dims[rank-1]
         if rank > 1:
             nrows = dims[rank-2]
         else:
-            nrows = 1 
-        
+            nrows = 1
+
         # use some rough heuristics to define the selection
         if ncols > 100:
             ncols = 100
@@ -1070,7 +1051,7 @@ class DatasetHandler(BaseHandler):
             nrows = 100
         if nrows*ncols > 1000:
             nrows /= 10
-                       
+
         for i in range(rank):
             if i == rank-1:
                 select += "0:" + str(ncols)
@@ -1080,20 +1061,19 @@ class DatasetHandler(BaseHandler):
                 select += "0:1,"
         select += "]"
         return select
-                
-         
-        
+
+
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('DatasetHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('DatasetHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
@@ -1105,61 +1085,60 @@ class DatasetHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 item = db.getDatasetItemByUuid(reqUuid)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-        
-          
+            raise HTTPError(status, reason=e.strerror)
+
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
-        previewQuery = self.getPreviewQuery(item['shape'])  
+        previewQuery = self.getPreviewQuery(item['shape'])
         if hostQuery and previewQuery:
             previewQuery += "&host=" + self.get_query_argument("host")
-             
+
         hrefs.append({'rel': 'self',       'href': href + 'datasets/' + reqUuid + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'attributes', 'href': href + 'datasets/' + reqUuid + '/attributes' + hostQuery}) 
-        hrefs.append({'rel': 'data', 'href': href + 'datasets/' + reqUuid + '/value' + hostQuery}) 
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'attributes', 'href': href + 'datasets/' + reqUuid + '/attributes' + hostQuery})
+        hrefs.append({'rel': 'data', 'href': href + 'datasets/' + reqUuid + '/value' + hostQuery})
         if previewQuery:
-            hrefs.append({'rel': 'preview', 'href': href + 'datasets/' + reqUuid + '/value' + previewQuery}) 
-        hrefs.append({'rel': 'home', 'href': href + hostQuery})       
+            hrefs.append({'rel': 'preview', 'href': href + 'datasets/' + reqUuid + '/value' + previewQuery})
+        hrefs.append({'rel': 'home', 'href': href + hostQuery})
         response['id'] = reqUuid
         typeItem = item['type']
         response['type'] = hdf5dtype.getTypeResponse(typeItem)
         response['shape'] = item['shape']
-         
+
         if 'creationProperties' in item:
             response['creationProperties'] = item['creationProperties']
         response['created'] = unixTimeToUTC(item['ctime'])
         response['lastModified'] = unixTimeToUTC(item['mtime'])
         response['attributeCount'] = item['attributeCount']
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
-        
+
         json_rsp = json_encode(response)
-        
+
         self.write(json_rsp)
-        
-        
-    def delete(self): 
-        log = logging.getLogger("h5serv")
-        log.info('DatasetHandler.delete host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+
+
+    def delete(self):
+        logger.info('DatasetHandler.delete host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         req_uuid = self.getRequestId()
         domain = self.getDomain()
         filePath = getFilePath(domain)
         verifyFile(filePath, True)
-        
-        response = {}        
+
+        response = {}
         hrefs = []
         rootUUID = None
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -1167,29 +1146,29 @@ class DatasetHandler(BaseHandler):
                 self.verifyAcl(acl, 'delete')  # throws exception is unauthorized
                 db.deleteObjectByUuid('dataset', req_uuid)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror)     
-                        
+            raise HTTPError(status, reason=e.strerror)
+
         # write the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'datasets' + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
         response['hrefs'] = hrefs
-         
+
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response)) 
-            
-                
+        self.write(json_encode(response))
+
+
 class ValueHandler(BaseHandler):
-     
+
     """
     Helper method - return slice for dim based on query params
-    
+
     Query arg should be in the form: [<dim1>, <dim2>, ... , <dimn>]
      brackets are optional for one dimensional arrays.
      Each dimension, valid formats are:
@@ -1199,33 +1178,32 @@ class ValueHandler(BaseHandler):
     """
 
     def getSliceQueryParam(self, dim, extent):
-        log = logging.getLogger("h5serv")
         # Get optional query parameters for given dim
-        log.info("getSliceQueryParam: " + str(dim) + ", " + str(extent))
-        query = self.get_query_argument("select", default='ALL') 
+        logger.info("getSliceQueryParam: " + str(dim) + ", " + str(extent))
+        query = self.get_query_argument("select", default='ALL')
         if query == 'ALL':
             # just return a slice for the entire dimension
-            log.info("getSliceQueryParam: return default")
+            logger.info("getSliceQueryParam: return default")
             return slice(0, extent)
-            
-        log.info("select query value: [" + query + "]");
-            
+
+        logger.info("select query value: [" + query + "]");
+
         if not query.startswith('['):
             msg = "Bad Request: selection query missing start bracket"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         if not query.endswith(']'):
             msg = "Bad Request: selection query missing end bracket"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
-            
+
         # now strip out brackets
         query = query[1:-1]
-        
+
         query_array = query.split(',')
         if dim > len(query_array):
             msg = "Not enough dimensions supplied to query argument"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         dim_query = query_array[dim].strip()
         start = 0
@@ -1237,7 +1215,7 @@ class ValueHandler(BaseHandler):
                 start = int(dim_query)
             except ValueError:
                 msg ="Bad Request: invalid selection parameter (can't convert to int) for dimension: " + str(dim)
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             stop = start
         elif dim_query == ':':
@@ -1247,8 +1225,8 @@ class ValueHandler(BaseHandler):
             fields = dim_query.split(":")
             if len(fields) > 3:
                 msg ="Bad Request: Too many ':' seperators for dimension: " + str(dim)
-                log.info(msg)
-                raise HTTPError(400, reason=msg)       
+                logger.info(msg)
+                raise HTTPError(400, reason=msg)
             try:
                 if fields[0]:
                     start = int(fields[0])
@@ -1258,108 +1236,106 @@ class ValueHandler(BaseHandler):
                     step = int(fields[2])
             except ValueError:
                 msg ="Bad Request: invalid selection parameter (can't convert to int) for dimension: " + str(dim)
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
-        
+
         if start < 0 or start > extent:
             msg = "Bad Request: Invalid selection start parameter for dimension: " + str(dim)
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         if stop > extent:
             msg = "Bad Request: Invalid selection stop parameter for dimension: " + str(dim)
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         if step <= 0:
             msg = "Bad Request: invalid selection step parameter for dimension: " + str(dim)
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         s = slice(start, stop, step)
-        log.info("dim query[" + str(dim) + "] returning: start: " + str(start) + " stop: " +
-             str(stop) + " step: " +  str(step)) 
+        logger.info("dim query[" + str(dim) + "] returning: start: " + str(start) + " stop: " +
+             str(stop) + " step: " +  str(step))
         return s
-    
-    
-        
+
+
+
     """
     Get slices given lists of start, stop, step values
     """
     def getHyperslabSelection(self, dsetshape, start, stop, step):
-        log = logging.getLogger("h5serv")
         rank = len(dsetshape)
         if start:
             if type(start) is not list:
                 start = [start,]
             if len(start) != rank:
                 msg = "Bad Request: start array length not equal to dataset rank"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             for dim in range(rank):
                 if start[dim] < 0 or start[dim] >= dsetshape[dim]:
                     msg = "Bad Request: start index invalid for dim: " + str(dim)
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(400, reason=msg)
         else:
             start = []
             for dim in range(rank):
                 start.append(0)
-        
+
         if stop:
             if type(stop) is not list:
                 stop = [stop,]
             if len(stop) != rank:
                 msg = "Bad Request: stop array length not equal to dataset rank"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             for dim in range(rank):
                 if stop[dim] <= start[dim] or stop[dim] > dsetshape[dim]:
                     msg = "Bad Request: stop index invalid for dim: " + str(dim)
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(400, reason=msg)
         else:
             stop = []
             for dim in range(rank):
                 stop.append(dsetshape[dim])
-        
+
         if step:
             if type(step) is not list:
                 step = [step,]
             if len(step) != rank:
                 msg = "Bad Request: step array length not equal to dataset rank"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             for dim in range(rank):
                 if step[dim] <= 0 or step[dim] > dsetshape[dim]:
                     msg = "Bad Request: step index invalid for dim: " + str(dim)
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(400, reason=msg)
         else:
             step = []
             for dim in range(rank):
                 step.append(1)
-            
+
         slices = []
         for dim in range(rank):
             try:
                 s = slice(int(start[dim]), int(stop[dim]), int(step[dim]))
             except ValueError:
                 msg = "Bad Request: invalid start/stop/step value"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             slices.append(s)
         return tuple(slices)
-    
-        
+
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('ValueHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('ValueHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
@@ -1371,8 +1347,8 @@ class ValueHandler(BaseHandler):
         slices = []
         query_selection = self.get_query_argument("query", default=None)
         if query_selection:
-            log.info("query: " + query_selection)
-        
+            logger.info("query: " + query_selection)
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -1380,11 +1356,11 @@ class ValueHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 item = db.getDatasetItemByUuid(reqUuid)
                 item_type = item['type']
-                
+
                 if item_type['class'] == 'H5T_OPAQUE':
                     #todo - support for returning OPAQUE data...
                     msg = "Not Implemented: GET OPAQUE data not supported"
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(501, reason=msg)  # Not implemented
                 item_shape = item['shape']
                 if item_shape['class'] == 'H5S_NULL':
@@ -1392,8 +1368,8 @@ class ValueHandler(BaseHandler):
                 elif item_shape['class'] == 'H5S_SCALAR':
                     if query_selection:
                         msg = "Bad Request: query selection not valid with scalar dataset"
-                        log.info(msg)
-                        raise HTTPError(400, reason=msg) 
+                        logger.info(msg)
+                        raise HTTPError(400, reason=msg)
                     values = db.getDatasetValuesByUuid(reqUuid, Ellipsis)
                 elif item_shape['class'] == 'H5S_SIMPLE':
                     dims = item_shape['dims']
@@ -1402,34 +1378,34 @@ class ValueHandler(BaseHandler):
                         slice = self.getSliceQueryParam(dim, dims[dim])
                         slices.append(slice)
                     if not query_selection:
-                        values = db.getDatasetValuesByUuid(reqUuid, tuple(slices)) 
+                        values = db.getDatasetValuesByUuid(reqUuid, tuple(slices))
                 else:
                     msg = "Internal Server Error: unexpected shape class: " + shape['class']
-                    log.error(msg)
+                    logger.error(msg)
                     raise HTTPError(500, reason=msg)
-                
+
                 rootUUID = db.getUUIDByPath('/')
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-            
+            raise HTTPError(status, reason=e.strerror)
+
         if query_selection:
             if item_type['class'] != 'H5T_COMPOUND':
                 msg = "Bad Request: query selection is only supported for compound types"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             if rank != 1:
                 msg = "Bad Request: query selection is only supported for "
                 msg += "one dimensional datasets"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             if 'alias' not in item or len(item['alias']) == 0:
                 msg = "Bad Request: query selection is not valid for "
                 msg += "anonymous datasets"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
-            
+
             dims = item_shape['dims']
             start = 0
             stop = dims[0]
@@ -1440,7 +1416,7 @@ class ValueHandler(BaseHandler):
                     limit = int(limit)  # convert to int
                 except ValueError as e:
                     msg = "Query error, invalid Limit: " + e.message
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(400, msg)
             if slices:
                 start=slices[0].start
@@ -1454,9 +1430,9 @@ class ValueHandler(BaseHandler):
                     response['index'] = rsp['indexes']
             except NameError as e:
                 msg = "Query error: " + e.message
-                log.info(msg)
-                raise HTTPError(400, msg)       
-                         
+                logger.info(msg)
+                raise HTTPError(400, msg)
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
@@ -1477,58 +1453,57 @@ class ValueHandler(BaseHandler):
             else:
                 selfQuery += '?'
             selfQuery += 'host=' + self.get_query_argument("host", default='')
-        
+
         if values is not None:
             response['value'] = values
         else:
             response['value'] = None
-        
+
         hrefs.append({'rel': 'self',  'href': href + 'datasets/' + reqUuid + '/value' + selfQuery})
-        hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'owner', 'href': href + 'datasets/' + reqUuid + hostQuery}) 
-        hrefs.append({'rel': 'home',  'href': href + hostQuery })   
+        hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'owner', 'href': href + 'datasets/' + reqUuid + hostQuery})
+        hrefs.append({'rel': 'home',  'href': href + hostQuery })
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response)) 
-        
+        self.write(json_encode(response))
+
     def post(self):
-        log = logging.getLogger("h5serv")
-        log.info('ValueHandler.post host=[' + self.request.host + '] uri=[' +
+        logger.info('ValueHandler.post host=[' + self.request.host + '] uri=[' +
              self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         body = None
         try:
             body = json.loads(self.request.body)
         except ValueError as e:
             msg = "JSON Parser Error: " + e.message
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg )
-        
+
         if "points" not in body:
             msg = "Bad Request: value post request without points in body"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         points = body['points']
         if type(points) != list:
             msg = "Bad Request: expecting list of points"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
-        
-        
+
+
         response = { }
         hrefs = []
         rootUUID = None
         item = None
         values = None
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -1538,92 +1513,91 @@ class ValueHandler(BaseHandler):
                 shape = item['shape']
                 if shape['class'] == 'H5S_SCALAR':
                     msg = "Bad Request: point selection is not supported on scalar datasets"
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(400, reason=msg)
                 rank = len(shape['dims'])
-                
+
                 for point in points:
                     if rank == 1 and type(point) != int:
                         msg = "Bad Request: elements of points should be int type for datasets of rank 1"
-                        log.info(msg)
+                        logger.info(msg)
                         raise HTTPError(400, reason=msg)
                     elif rank > 1 and type(point) != list:
                         msg = "Bad Request: elements of points should be list type for datasets of rank >1"
-                        log.info(msg)
+                        logger.info(msg)
                         raise HTTPError(400, reason=msg)
                         if len(point) != rank:
                             msg = "Bad Request: one or more points have a missing coordinate value"
-                            log.info(msg)
+                            logger.info(msg)
                             raise HTTPError(400, reason=msg)
-             
-                values = db.getDatasetPointSelectionByUuid(reqUuid, points) 
-              
+
+                values = db.getDatasetPointSelectionByUuid(reqUuid, points)
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
+            raise HTTPError(status, reason=e.strerror)
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         response['value'] = values
-        
+
         hrefs.append({'rel': 'self',  'href': href + 'datasets/' + reqUuid + '/value' + hostQuery})
-        hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'owner', 'href': href + 'datasets/' + reqUuid + hostQuery }) 
-        hrefs.append({'rel': 'home',  'href': href + hostQuery})   
+        hrefs.append({'rel': 'root',  'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'owner', 'href': href + 'datasets/' + reqUuid + hostQuery })
+        hrefs.append({'rel': 'home',  'href': href + hostQuery})
         #response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response))     
-    
+        self.write(json_encode(response))
+
     def put(self):
-        log = logging.getLogger("h5serv")
-        log.info('ValueHandler.put host=[' + self.request.host + '] uri=[' + 
+        logger.info('ValueHandler.put host=[' + self.request.host + '] uri=[' +
             self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
         points = None
         start = None
         stop = None
         step = None
-        
+
         body = None
         try:
             body = json.loads(self.request.body)
         except ValueError as e:
             msg = "JSON Parser Error: " + e.message
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg )
-        
+
         if "value" not in body:
             msg = "Bad Request: Value not specified"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg) # missing data
-            
+
         data = body["value"]
-        
-            
+
+
         if "points" in body:
             points = body['points']
             if type(points) != list:
                 msg = "Bad Request: expecting list of points"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             if 'start' in body or 'stop' in body or 'step' in body:
                 msg = "Bad Request: can use hyperslab selection and points selection in one request"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             if len(points) > len(data):
                 msg = "Bad Request: more points provided than values"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
         else:
             # hyperslab selection
@@ -1633,8 +1607,8 @@ class ValueHandler(BaseHandler):
                 stop = body['stop']
             if 'step' in body:
                 step = body['step']
-                            
-        
+
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -1645,18 +1619,18 @@ class ValueHandler(BaseHandler):
                 dims = dsetshape['dims']
                 if points:
                     # write point selection
-                    db.setDatasetValuesByPointSelection(reqUuid, data, points)              
+                    db.setDatasetValuesByPointSelection(reqUuid, data, points)
                 else:
                     slices = self.getHyperslabSelection(dims, start, stop, step)
                     # todo - check that the types are compatible
                     db.setDatasetValuesByUuid(reqUuid, data, slices)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-        
-        log.info("value post succeeded")   
-           
+            raise HTTPError(status, reason=e.strerror)
+
+        logger.info("value post succeeded")
+
 class AttributeHandler(BaseHandler):
 
     # convert embedded list (list of lists) to tuples
@@ -1668,11 +1642,10 @@ class AttributeHandler(BaseHandler):
             return tuple(sublist)
         else:
             return data
-    
-        
+
+
     def getRequestName(self):
-        log = logging.getLogger("h5serv")
-        # request is in the form /(datasets|groups|datatypes)/<id>/attributes(/<name>), 
+        # request is in the form /(datasets|groups|datatypes)/<id>/attributes(/<name>),
         # return <name>
         # return None if the uri doesn't end with ".../<name>"
         uri = self.request.uri
@@ -1680,8 +1653,8 @@ class AttributeHandler(BaseHandler):
         npos = uri.rfind('/attributes')
         if npos <= 0:
             msg = "Bad Request: URI is invalid"
-            log.info(msg)
-            raise HTTPError(400, reason=msg)  
+            logger.info(msg)
+            raise HTTPError(400, reason=msg)
         uri = uri[npos+len('/attributes'):]
         if uri[0:1] == '/':
             uri = uri[1:]
@@ -1691,46 +1664,44 @@ class AttributeHandler(BaseHandler):
                 if npos > 0:
                     uri = uri[:npos]
                 name = url_unescape(uri)  # todo: handle possible query string?
-                log.info('got name: [' + name + ']')     
-    
+                logger.info('got name: [' + name + ']')
+
         return name
-        
+
     def getRequestCollectionName(self):
-        log = logging.getLogger("h5serv")
-        # request is in the form /(datasets|groups|datatypes)/<id>/attributes(/<name>), 
+        # request is in the form /(datasets|groups|datatypes)/<id>/attributes(/<name>),
         # return datasets | groups | datatypes
         uri = self.request.uri
-        
+
         npos = uri.find('/')
         if npos < 0:
-            log.info("bad uri")
-            raise HTTPError(400)  
+            logger.info("bad uri")
+            raise HTTPError(400)
         uri = uri[(npos+1):]
         npos = uri.find('/')  # second '/'
         col_name = uri[:npos]
-         
-        log.info('got collection name: [' + col_name + ']')
+
+        logger.info('got collection name: [' + col_name + ']')
         if col_name not in ('datasets', 'groups', 'datatypes'):
             msg = "Internal Server Error: collection name unexpected"
-            log.error(msg)
+            logger.error(msg)
             raise HTTPError(500, reason=msg)   # shouldn't get routed here in this case
-    
+
         return col_name
-        
-        
+
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('AttributeHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('AttributeHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
         domain = self.getDomain()
         col_name = self.getRequestCollectionName()
         attr_name = self.getRequestName()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
@@ -1741,11 +1712,11 @@ class AttributeHandler(BaseHandler):
             try:
                 limit = int(limit)
             except ValueError:
-                log.info("expected int type for limit")
-                raise HTTPError(400) 
+                logger.info("expected int type for limit")
+                raise HTTPError(400)
         marker = self.get_query_argument("Marker", None)
-        
-        
+
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -1757,24 +1728,24 @@ class AttributeHandler(BaseHandler):
                 else:
                     # get all attributes (but without data)
                     items = db.getAttributeItems(col_name, reqUuid, marker, limit)
-                
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
-        
+            raise HTTPError(status, reason=e.strerror)
+
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         root_href = href + 'groups/' + rootUUID
-        owner_href = href + col_name + '/' + reqUuid 
+        owner_href = href + col_name + '/' + reqUuid
         self_href = owner_href + '/attributes'
         if attr_name != None:
             self_href += '/' + url_escape(attr_name)
-    
+
         responseItems = []
         for item in items:
             responseItem = {}
@@ -1782,8 +1753,8 @@ class AttributeHandler(BaseHandler):
             typeItem = item['type']
             responseItem['type'] = hdf5dtype.getTypeResponse(typeItem)
             responseItem['shape'] = item['shape']
-            responseItem['created'] = unixTimeToUTC(item['ctime']) 
-            responseItem['lastModified'] = unixTimeToUTC(item['mtime']) 
+            responseItem['created'] = unixTimeToUTC(item['ctime'])
+            responseItem['lastModified'] = unixTimeToUTC(item['mtime'])
             if not attr_name or typeItem['class'] == 'H5T_OPAQUE':
                 pass # todo - send data for H5T_OPAQUE's
             elif 'value' in item:
@@ -1793,104 +1764,103 @@ class AttributeHandler(BaseHandler):
             if attr_name is None:
                 # add an href to the attribute
                 responseItem['href'] = self_href + '/' + url_escape(item['name']) + hostQuery
-            
+
             responseItems.append(responseItem)
-            
+
         hrefs.append({'rel': 'self',       'href': self_href + hostQuery})
         hrefs.append({'rel': 'owner',      'href': owner_href + hostQuery})
-        hrefs.append({'rel': 'root',       'href': root_href + hostQuery }) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
-        
-            
+        hrefs.append({'rel': 'root',       'href': root_href + hostQuery })
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
+
+
         if attr_name == None:
             # specific attribute response
             response['attributes'] = responseItems
         else:
             if len(responseItems) == 0:
                 # should have raised exception earlier
-                log.error("attribute not found: " + attr_name) 
+                logger.error("attribute not found: " + attr_name)
                 raise HTTPError(404)
             responseItem = responseItems[0]
             for k in responseItem:
                 response[k] = responseItem[k]
 
-        
-        response['hrefs'] = hrefs   
-         
-        
+
+        response['hrefs'] = hrefs
+
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-        
+
     def put(self):
-        log = logging.getLogger("h5serv")
-        log.info('AttributeHandler.put host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('AttributeHandler.put host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         domain = self.getDomain()
         col_name = self.getRequestCollectionName()
         reqUuid = self.getRequestId()
         attr_name = self.getRequestName()
         if attr_name == None:
             msg = "Bad Request: attribute name not supplied"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         body = None
         try:
             body = json.loads(self.request.body)
         except ValueError as e:
             msg = "JSON Parser Error: " + e.message
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg )
-            
+
         if "type" not in body:
-            log.info("Type not supplied")
+            logger.info("Type not supplied")
             raise HTTPError(400)  # missing type
-    
-          
+
+
         dims = () # default as empty tuple (will create a scalar attribute)
-        if "shape" in body:  
+        if "shape" in body:
             shape = body["shape"]
             if type(shape) == int:
                 dims = [shape,]
-            elif type(shape) == list or type(shape) == tuple: 
+            elif type(shape) == list or type(shape) == tuple:
                 dims = shape # can use as is
             elif type(shape) in (str, unicode) and shape == 'H5S_NULL':
                 dims = None
             else:
                 msg="Bad Request: shape is invalid"
-                log.info(msg)
-                raise HTTPError(400, reason=msg)  
+                logger.info(msg)
+                raise HTTPError(400, reason=msg)
         datatype = body["type"]
-         
+
         # validate shape
         if dims:
             for extent in dims:
                 if type(extent) != int:
                     msg = "Bad Request: invalid shape type"
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(400, reason=msg)
                 if extent < 0:
                     msg = "Bad Request: invalid shape (negative extent)"
-                    log.info(msg)
-                    raise HTTPError(400, reason=msg)   
-                
+                    logger.info(msg)
+                    raise HTTPError(400, reason=msg)
+
         # convert list values to tuples (otherwise h5py is not happy)
         data = None
-         
+
         if dims != None:
             if "value" not in body:
                 msg = "Bad Request: value not specified"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)  # missing value
             value = body["value"]
-             
+
             data = self.convertToTuple(value)
-             
-                   
+
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -1898,121 +1868,119 @@ class AttributeHandler(BaseHandler):
                 self.verifyAcl(acl, 'create')  # throws exception is unauthorized
                 db.createAttribute(col_name, reqUuid, attr_name, dims, datatype, data)
                 rootUUID = db.getUUIDByPath('/')
-                 
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                
+            raise HTTPError(status, reason=e.strerror)
+
         response = { }
-      
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
-        root_href = href + 'groups/' + rootUUID 
-        owner_href = href + col_name + '/' + reqUuid 
+        root_href = href + 'groups/' + rootUUID
+        owner_href = href + col_name + '/' + reqUuid
         self_href = owner_href + '/attributes'
         if attr_name != None:
             self_href += '/' + attr_name
-            
+
         hrefs = [ ]
         hrefs.append({'rel': 'self',   'href': self_href + hostQuery})
         hrefs.append({'rel': 'owner',  'href': owner_href + hostQuery})
-        hrefs.append({'rel': 'root',   'href': root_href + hostQuery}) 
-        response['hrefs'] = hrefs 
-        
+        hrefs.append({'rel': 'root',   'href': root_href + hostQuery})
+        response['hrefs'] = hrefs
+
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response))  
+        self.write(json_encode(response))
         self.set_status(201)  # resource created
-        
-    def delete(self): 
-        log = logging.getLogger("h5serv")
-        log.info('AttributeHandler.delete ' + self.request.host)   
-        log.info('remote_ip: ' + self.request.remote_ip)
+
+    def delete(self):
+        logger.info('AttributeHandler.delete ' + self.request.host)
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         obj_uuid = self.getRequestId()
         domain = self.getDomain()
         col_name = self.getRequestCollectionName()
         attr_name = self.getRequestName()
         if attr_name == None:
             msg = "Bad Request: attribute name not specified"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)
         filePath = getFilePath(domain)
         verifyFile(filePath, True)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
                 acl = db.getAcl(obj_uuid, self.userid)
                 self.verifyAcl(acl, 'delete')  # throws exception is unauthorized
                 db.deleteAttribute(col_name, obj_uuid, attr_name)
-                
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-            
+            raise HTTPError(status, reason=e.strerror)
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
-            hostQuery = "?host=" + self.get_query_argument("host") 
-        root_href = href + 'groups/' + rootUUID 
+            hostQuery = "?host=" + self.get_query_argument("host")
+        root_href = href + 'groups/' + rootUUID
         owner_href = href + col_name + '/' + obj_uuid
-        self_href = owner_href + '/attributes' 
-            
+        self_href = owner_href + '/attributes'
+
         hrefs.append({'rel': 'self',       'href': self_href + hostQuery})
         hrefs.append({'rel': 'owner',      'href': owner_href + hostQuery})
-        hrefs.append({'rel': 'root',       'href': root_href + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery }) 
-        response['hrefs'] = hrefs 
-        
+        hrefs.append({'rel': 'root',       'href': root_href + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery })
+        response['hrefs'] = hrefs
+
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response))  
-        
-        log.info("Attribute delete succeeded")
-                
-         
+        self.write(json_encode(response))
+
+        logger.info("Attribute delete succeeded")
+
+
 class GroupHandler(BaseHandler):
-            
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('GroupHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('GroupHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         reqUuid = self.getRequestId()
-            
+
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         response = { }
-             
+
         hrefs = []
         rootUUID = None
         item = None
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
-                rootUUID = db.getUUIDByPath('/')             
+                rootUUID = db.getUUIDByPath('/')
                 acl = db.getAcl(reqUuid, self.userid)
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 item = db.getGroupItemByUuid(reqUuid)
-                
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
+            raise HTTPError(status, reason=e.strerror)
+
         # got everything we need, put together the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
@@ -2020,88 +1988,86 @@ class GroupHandler(BaseHandler):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'groups/' + reqUuid + hostQuery})
         hrefs.append({'rel': 'links',      'href': href + 'groups/' + reqUuid + '/links' + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
-        hrefs.append({'rel': 'attributes', 'href': href + 'groups/' + reqUuid + '/attributes' + hostQuery})        
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
+        hrefs.append({'rel': 'attributes', 'href': href + 'groups/' + reqUuid + '/attributes' + hostQuery})
         response['id'] = reqUuid
         response['created'] = unixTimeToUTC(item['ctime'])
         response['lastModified'] = unixTimeToUTC(item['mtime'])
         response['attributeCount'] = item['attributeCount']
         response['linkCount'] = item['linkCount']
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-        
-    def delete(self): 
-        log = logging.getLogger("h5serv")
-        log.info('GroupHandler.delete ' + self.request.host)   
-        log.info('remote_ip: ' + self.request.remote_ip)
+
+    def delete(self):
+        logger.info('GroupHandler.delete ' + self.request.host)
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         req_uuid = self.getRequestId()
         domain = self.getDomain()
         filePath = getFilePath(domain)
         verifyFile(filePath, True)
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
-                rootUUID = db.getUUIDByPath('/')             
+                rootUUID = db.getUUIDByPath('/')
                 acl = db.getAcl(req_uuid, self.userid)
                 self.verifyAcl(acl, 'delete')  # throws exception is unauthorized
                 db.deleteObjectByUuid('group', req_uuid)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-         
-        response = {}        
+            raise HTTPError(status, reason=e.strerror)
+
+        response = {}
         hrefs = []
-                        
+
         # write the response
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'groups' + hostQuery })
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery} ) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery} )
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
         response['hrefs'] = hrefs
-         
+
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response)) 
-        
-    
-                
+        self.write(json_encode(response))
+
+
+
 class GroupCollectionHandler(BaseHandler):
-            
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('GroupCollectionHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('GroupCollectionHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
-                
+
+
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
         rootUUID = None
-        
+
         # Get optional query parameters
         limit = self.get_query_argument("Limit", 0)
         if type(limit) is not int:
             try:
                 limit = int(limit)
             except ValueError:
-                log.info("expected int type for limit")
-                raise HTTPError(400) 
+                logger.info("expected int type for limit")
+                raise HTTPError(400)
         marker = self.get_query_argument("Marker", None)
-        
+
         response = { }
-             
+
         items = None
         hrefs = []
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -2109,10 +2075,10 @@ class GroupCollectionHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 items = db.getCollection("groups", marker, limit)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
+            raise HTTPError(status, reason=e.strerror)
+
         # write the response
         response['groups'] = items
         href = self.request.protocol + '://' + self.request.host + '/'
@@ -2120,72 +2086,71 @@ class GroupCollectionHandler(BaseHandler):
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'groups'  + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
         response['hrefs'] = hrefs
-         
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-        
+
     def post(self):
-        log = logging.getLogger("h5serv")
-        log.info('GroupHandlerCollection.post host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('GroupHandlerCollection.post host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         if self.request.uri != '/groups':
             msg = "Method Not Allowed: bad group post request"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(405, reason=msg)  # Method not allowed
         self.get_current_user()
-        
+
         parent_group_uuid = None
         link_name = None
-        
+
         body = {}
         if self.request.body:
             try:
                 body = json.loads(self.request.body)
             except ValueError as e:
                 msg = "JSON Parser Error: " + e.message
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg )
-        
-        if "link" in body:    
+
+        if "link" in body:
             link_options = body["link"]
             if "id" not in link_options or "name" not in link_options:
                 msg = "Bad Request: missing link parameter"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             parent_group_uuid = link_options["id"]
             link_name = link_options["name"]
-            log.info("add link to: " + parent_group_uuid + " with name: " + link_name)
-               
+            logger.info("add link to: " + parent_group_uuid + " with name: " + link_name)
+
         domain = self.getDomain()
         filePath = getFilePath(domain)
         verifyFile(filePath, True)
-              
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
                 current_user_acl = db.getAcl(rootUUID, self.userid)
-           
+
                 self.verifyAcl(current_user_acl, 'create')  # throws exception is unauthorized
                 grpUUID = db.createGroup()
                 item = db.getGroupItemByUuid(grpUUID)
                 # if link info is provided, link the new group
                 if parent_group_uuid:
                     # link the new dataset
-                    db.linkObject(parent_group_uuid, grpUUID, link_name) 
+                    db.linkObject(parent_group_uuid, grpUUID, link_name)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror)      
-           
-        href = self.request.protocol + '://' + domain  
+            raise HTTPError(status, reason=e.strerror)
+
+        href = self.request.protocol + '://' + domain
         self.set_header('Location', href + '/groups/' + grpUUID)
         self.set_header('Content-Location', href + '/groups/' + grpUUID)
-        
+
         # got everything we need, put together the response
-        response = { } 
+        response = { }
         hrefs = []
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
@@ -2193,33 +2158,32 @@ class GroupCollectionHandler(BaseHandler):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'groups/' + grpUUID + hostQuery})
         hrefs.append({'rel': 'links',      'href': href + 'groups/' + grpUUID + '/links' + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
-        hrefs.append({'rel': 'attributes', 'href': href + 'groups/' + grpUUID + '/attributes' + hostQuery})        
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
+        hrefs.append({'rel': 'attributes', 'href': href + 'groups/' + grpUUID + '/attributes' + hostQuery})
         response['id'] = grpUUID
         response['created'] = unixTimeToUTC(item['ctime'])
         response['lastModified'] = unixTimeToUTC(item['mtime'])
         response['attributeCount'] = item['attributeCount']
         response['linkCount'] = item['linkCount']
         response['hrefs'] = hrefs
-        
+
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response))               
+        self.write(json_encode(response))
         self.set_status(201)  # resource created
-        
-        
+
+
 class DatasetCollectionHandler(BaseHandler):
-            
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('DatasetCollectionHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('DatasetCollectionHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         # Get optional query parameters
         limit = self.get_query_argument("Limit", 0)
         if type(limit) is not int:
@@ -2227,16 +2191,16 @@ class DatasetCollectionHandler(BaseHandler):
                 limit = int(limit)
             except ValueError:
                 msg = "Bad Request: expected int type for limit"
-                log.info(msg)
-                raise HTTPError(400, reason=msg) 
+                logger.info(msg)
+                raise HTTPError(400, reason=msg)
         marker = self.get_query_argument("Marker", None)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
-             
+
         items = None
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -2244,10 +2208,10 @@ class DatasetCollectionHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 items = db.getCollection("datasets", marker, limit)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
+            raise HTTPError(status, reason=e.strerror)
+
         # write the response
         response['datasets'] = items
         href = self.request.protocol + '://' + self.request.host + '/'
@@ -2255,117 +2219,116 @@ class DatasetCollectionHandler(BaseHandler):
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'datasets' + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery }) 
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery })
         response['hrefs'] = hrefs
-         
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-        
+
     def post(self):
-        log = logging.getLogger("h5serv")
-        log.info('DatasetHandler.post host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('DatasetHandler.post host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         if self.request.uri != '/datasets':
             msg = "Method not Allowed: invalid datasets post request"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(405, reason=msg)  # Method not allowed
-               
+
         domain = self.getDomain()
         filePath = getFilePath(domain)
         verifyFile(filePath, True)
         dims = None
         group_uuid = None
         link_name = None
-        
+
         body = None
         try:
             body = json.loads(self.request.body)
         except ValueError as e:
             msg = "JSON Parser Error: " + e.message
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg )
-        
+
         if "type" not in body:
             msg = "Bad Request: Type not specified"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)  # missing type
-            
+
         if "shape" in body:
             shape = body["shape"]
             if type(shape) == int:
                 dims = [shape,]
-            elif type(shape) == list or type(shape) == tuple: 
+            elif type(shape) == list or type(shape) == tuple:
                 dims = shape # can use as is
             elif type(shape) in (str, unicode) and shape == 'H5S_NULL':
                 dims = None
             else:
                 msg="Bad Request: shape is invalid"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
         else:
             dims = ()  # empty tuple
-            
-        if "link" in body:          
+
+        if "link" in body:
             link_options = body["link"]
             if "id" not in link_options or "name" not in link_options:
                 msg="Bad Request: No 'name' or 'id' not specified"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
-                
+
             group_uuid = link_options["id"]
             link_name = link_options["name"]
-            log.info("add link to: " + group_uuid + " with name: " + link_name);
-            
+            logger.info("add link to: " + group_uuid + " with name: " + link_name);
+
         datatype = body["type"]
-        
+
         maxdims = None
         if "maxdims" in body:
             maxdims = body["maxdims"]
             if type(maxdims) == int:
                 dim1 = maxdims
                 maxdims = [dim1]
-            elif type(maxdims) == list or type(maxdims) == tuple: 
+            elif type(maxdims) == list or type(maxdims) == tuple:
                 pass # can use as is
             else:
                 msg="Bad Request: maxdims is invalid"
-                log.info(msg)
-                raise HTTPError(400, reason=msg)     
-           
+                logger.info(msg)
+                raise HTTPError(400, reason=msg)
+
         # validate shape
         if dims:
             for extent in dims:
                 if type(extent) != int:
                     msg="Bad Request: Invalid shape type"
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(400, reason=msg)
                 if extent < 0:
                     msg="Bad Request: shape dimension is negative"
-                    log.info("msg")
-                    raise HTTPError(400, reason=msg) 
-            
+                    logger.info("msg")
+                    raise HTTPError(400, reason=msg)
+
         if maxdims:
             if dims == None:
                 # can't use maxdims with null_space dataset
                 msg="Bad Request: maxdims not valid for H5S_NULL dataspace"
-                log.info(msg)
-                raise HTTPError(400, reason=msg) 
-                
+                logger.info(msg)
+                raise HTTPError(400, reason=msg)
+
             if len(maxdims) != len(dims):
                 msg="Bad Request: maxdims array length must equal shape array length"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             for i in range(len(dims)):
                 maxextent = maxdims[i]
                 if maxextent != 0 and maxextent < dims[i]:
                     msg="Bad Request: maxdims extent can't be smaller than shape extent"
-                    log.info(msg)
+                    logger.info(msg)
                     raise HTTPError(400, reason=msg)
                 if maxextent == 0:
                     maxdims[i] = None  # this indicates unlimited
-        
+
         creationProps = None
         if "creationProperties" in body:
             creationProps = body["creationProperties"]
@@ -2379,18 +2342,18 @@ class DatasetCollectionHandler(BaseHandler):
                 if group_uuid and group_uuid != rootUUID:
                     acl = db.getAcl(group_uuid, self.userid)
                     self.verifyAcl(acl, 'create')  # throws exception is unauthorized
-                    
+
                 item = db.createDataset(datatype, dims, maxdims, creation_props=creationProps)
                 if group_uuid:
                     # link the new dataset
                     db.linkObject(group_uuid, item['id'], link_name)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                
+            raise HTTPError(status, reason=e.strerror)
+
         response = { }
-      
+
         # got everything we need, put together the response
         hrefs = [ ]
         href = self.request.protocol + '://' + self.request.host + '/'
@@ -2398,31 +2361,30 @@ class DatasetCollectionHandler(BaseHandler):
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'datasets/' + item['id'] + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'attributes', 'href': href + 'datasets/' + item['id'] + '/attributes' + hostQuery})   
-        hrefs.append({'rel': 'value', 'href': href + 'datasets/' + item['id'] + '/value' + hostQuery})        
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'attributes', 'href': href + 'datasets/' + item['id'] + '/attributes' + hostQuery})
+        hrefs.append({'rel': 'value', 'href': href + 'datasets/' + item['id'] + '/value' + hostQuery})
         response['id'] = item['id']
         response['attributeCount'] = item['attributeCount']
         response['hrefs'] = hrefs
         response['created'] = unixTimeToUTC(item['ctime'])
         response['lastModified'] = unixTimeToUTC(item['mtime'])
-        
+
         self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response))  
+        self.write(json_encode(response))
         self.set_status(201)  # resource created
-        
+
 class TypeCollectionHandler(BaseHandler):
-     
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('TypeCollectionHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('TypeCollectionHandler.get host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         domain = self.getDomain()
-        filePath = getFilePath(domain) 
+        filePath = getFilePath(domain)
         verifyFile(filePath)
-        
+
         # Get optional query parameters
         limit = self.get_query_argument("Limit", 0)
         if type(limit) is not int:
@@ -2430,14 +2392,14 @@ class TypeCollectionHandler(BaseHandler):
                 limit = int(limit)
             except ValueError:
                 msg = "Bad Request: expected int type for Limit"
-                log.info(msg)
-                raise HTTPError(400, reason=msg) 
+                logger.info(msg)
+                raise HTTPError(400, reason=msg)
         marker = self.get_query_argument("Marker", None)
-        
+
         response = { }
         hrefs = []
         rootUUID = None
-             
+
         items = None
         try:
             with Hdf5db(filePath) as db:
@@ -2446,72 +2408,71 @@ class TypeCollectionHandler(BaseHandler):
                 self.verifyAcl(acl, 'read')  # throws exception is unauthorized
                 items = db.getCollection("datatypes", marker, limit)
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-                         
+            raise HTTPError(status, reason=e.strerror)
+
         # write the response
         response['datatypes'] = items
-    
+
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'datatypes' + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery}) 
-        hrefs.append({'rel': 'home',       'href': href + hostQuery}) 
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID + hostQuery})
+        hrefs.append({'rel': 'home',       'href': href + hostQuery})
         response['hrefs'] = hrefs
-        
-         
+
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
-        
+
     def post(self):
-        log = logging.getLogger("h5serv")
-        log.info('TypeHandler.post host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('TypeHandler.post host=[' + self.request.host + '] uri=[' + self.request.uri + ']')
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         if self.request.uri != '/datatypes':
             msg = "Method not Allowed: invalid URI"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(405, reason=msg)  # Method not allowed
-               
+
         domain = self.getDomain()
         filePath = getFilePath(domain)
         verifyFile(filePath, True)
-        
+
         body = None
         try:
             body = json.loads(self.request.body)
         except ValueError as e:
             msg = "JSON Parser Error: " + e.message
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg )
-            
+
         parent_group_uuid = None
         link_name = None
-        
+
         if "type" not in body:
             msg = "Type not specified"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(400, reason=msg)  # missing type
-            
-        if "link" in body:    
+
+        if "link" in body:
             link_options = body["link"]
             if "id" not in link_options or "name" not in link_options:
                 msg = "Bad Request: missing link parameter"
-                log.info(msg)
+                logger.info(msg)
                 raise HTTPError(400, reason=msg)
             parent_group_uuid = link_options["id"]
             link_name = link_options["name"]
-            log.info("add link to: " + parent_group_uuid + " with name: " + link_name)
-            
-        datatype = body["type"]     
-        
+            logger.info("add link to: " + parent_group_uuid + " with name: " + link_name)
+
+        datatype = body["type"]
+
         item = None
         rootUUID = None
-     
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
@@ -2521,15 +2482,15 @@ class TypeCollectionHandler(BaseHandler):
                 # if link info is provided, link the new group
                 if parent_group_uuid:
                     # link the new dataset
-                    db.linkObject(parent_group_uuid, item['id'], link_name) 
-                            
+                    db.linkObject(parent_group_uuid, item['id'], link_name)
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-            
+            raise HTTPError(status, reason=e.strerror)
+
         response = { }
-      
+
         # got everything we need, put together the response
         hrefs = [ ]
         href = self.request.protocol + '://' + self.request.host + '/'
@@ -2537,60 +2498,59 @@ class TypeCollectionHandler(BaseHandler):
         if self.get_query_argument("host", default=None):
             hostQuery = "?host=" + self.get_query_argument("host")
         hrefs.append({'rel': 'self',       'href': href + 'datatypes/' + item['id'] + hostQuery})
-        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID}) 
-        hrefs.append({'rel': 'attributes', 'href': href + 'datatypes/' + item['id'] + '/attributes' + hostQuery})   
+        hrefs.append({'rel': 'root',       'href': href + 'groups/' + rootUUID})
+        hrefs.append({'rel': 'attributes', 'href': href + 'datatypes/' + item['id'] + '/attributes' + hostQuery})
         response['id'] = item['id']
         response['attributeCount'] = 0
         response['hrefs'] = hrefs
         response['created'] = unixTimeToUTC(item['ctime'])
         response['lastModified'] = unixTimeToUTC(item['mtime'])
-        
-        self.set_header('Content-Type', 'application/json')
-        self.write(json_encode(response)) 
-        self.set_status(201)  # resource created
-          
 
-            
-class RootHandler(BaseHandler): 
-    
+        self.set_header('Content-Type', 'application/json')
+        self.write(json_encode(response))
+        self.set_status(201)  # resource created
+
+
+
+class RootHandler(BaseHandler):
+
     """
     Helper method - get group uuid of hardlink, or None if no link
     """
     def getSubgroupId(self, db, group_uuid, link_name):
         subgroup_uuid = None
-        try:    
+        try:
             item = db.getLinkItemByUuid(group_uuid, link_name)
             if item['class'] != 'H5L_TYPE_HARD':
                 return None
             if item['collection'] != 'groups':
                 return None
-            subgroup_uuid = item['id']                 
+            subgroup_uuid = item['id']
         except IOError as e:
             # link_name doesn't exist, return None
-            pass               
-                
+            pass
+
         return subgroup_uuid
-             
+
     """
     Helper method - update TOC when a domain is created
-      If validateOnly is true, then the acl is checked to verify that create is 
+      If validateOnly is true, then the acl is checked to verify that create is
       enabled, but doesn't update the .toc
-    """    
+    """
     def addTocEntry(self, domain, filePath, validateOnly=False):
-        log = logging.getLogger("h5serv")
         hdf5_ext = config.get('hdf5_ext')
         dataPath = config.get('datapath')
-        log.info("addTocEntry - domain: " + domain + " filePath: " + filePath)
+        logger.info("addTocEntry - domain: " + domain + " filePath: " + filePath)
         verifyFile(filePath)   # create TOC file if it does not exist already
         if not filePath.startswith(dataPath):
-            log.error("unexpected filepath: " + filePath)
+            logger.error("unexpected filepath: " + filePath)
             raise HTTPError(500)
         filePath = filePath[len(dataPath):]
         tocFile = getTocFilePath()
         acl = None
-         
+
         try:
-            with Hdf5db(tocFile, app_logger=log) as db:             
+            with Hdf5db(tocFile, app_logger=log) as db:
                 group_uuid = db.getUUIDByPath('/')
                 pathNames = filePath.split('/')
                 for linkName in pathNames:
@@ -2605,74 +2565,72 @@ class RootHandler(BaseHandler):
                             acl = db.getAcl(group_uuid, self.userid)
                             self.verifyAcl(acl, 'create')  # throws exception is unauthorized
                             # create subgroup and link to parent group
-                            subgroup_uuid = db.createGroup()        
+                            subgroup_uuid = db.createGroup()
                             # link the new group
                             db.linkObject(group_uuid, subgroup_uuid, linkName)
-                        group_uuid = subgroup_uuid 
-                                              
+                        group_uuid = subgroup_uuid
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
             raise e
-            
+
     """
     Helper method - update TOC when a domain is deleted
-    """    
+    """
     def removeTocEntry(self, domain, filePath):
-        log = logging.getLogger("h5serv")
         hdf5_ext = config.get('hdf5_ext')
         dataPath = config.get('datapath')
-        
+
         if not filePath.startswith(dataPath):
-            log.error("unexpected filepath: " + filePath)
+            logger.error("unexpected filepath: " + filePath)
             raise HTTPError(500)
         filePath = filePath[len(dataPath):]
         tocFile = getTocFilePath()
-        log.info("removeTocEntry - domain: " + domain + " filePath: " + filePath)
-             
+        logger.info("removeTocEntry - domain: " + domain + " filePath: " + filePath)
+
         try:
-            with Hdf5db(tocFile, app_logger=log) as db:             
+            with Hdf5db(tocFile, app_logger=log) as db:
                 group_uuid = db.getUUIDByPath('/')
                 pathNames = filePath.split('/')
                 for linkName in pathNames:
                     if linkName.endswith(hdf5_ext):
                         linkName = linkName[:-(len(hdf5_ext))]
-                        log.info("unklink " + group_uuid + ", " + linkName)
+                        logger.info("unklink " + group_uuid + ", " + linkName)
                         db.unlinkItem(group_uuid, linkName)
                     else:
                         subgroup_uuid = self.getSubgroupId(db, group_uuid, linkName)
                         if subgroup_uuid is None:
                             msg = "Didn't find expected subgroup: " + group_uuid
-                            log.error(msg)
+                            logger.error(msg)
                             raise HTTPError(500, reason=msg)
-                        group_uuid = subgroup_uuid 
-                                              
+                        group_uuid = subgroup_uuid
+
         except IOError as e:
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
             raise e
-                    
-                
+
+
 
     def getRootResponse(self, filePath):
-        log = logging.getLogger("h5serv")
         acl = None
         # used by GET / and PUT /
-        
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
                 acl = db.getAcl(rootUUID, self.userid)
-                
-        except IOError as e:         
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+
+        except IOError as e:
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-        domain = self.getDomain() 
-        
+            raise HTTPError(status, reason=e.strerror)
+        domain = self.getDomain()
+
         self.verifyAcl(acl, 'read')  # throws exception is unauthorized
-            
-        # generate response 
+
+        # generate response
         hrefs = [ ]
         href = self.request.protocol + '://' + self.request.host + '/'
         hostQuery = ''
@@ -2683,19 +2641,18 @@ class RootHandler(BaseHandler):
         hrefs.append({'rel': 'groupbase', 'href': href + 'groups' + hostQuery})
         hrefs.append({'rel': 'typebase', 'href': href + 'datatypes' + hostQuery })
         hrefs.append({'rel': 'root',     'href': href + 'groups/' + rootUUID + hostQuery})
-            
+
         response = {  }
         response['created'] = unixTimeToUTC(op.getctime(filePath))
         response['lastModified'] = unixTimeToUTC(op.getmtime(filePath))
         response['root'] = rootUUID
-        response['hrefs'] = hrefs  
-      
+        response['hrefs'] = hrefs
+
         return response
-        
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('RootHandler.get ' + self.request.host)
-        log.info('remote_ip: ' + self.request.remote_ip)
+        logger.info('RootHandler.get ' + self.request.host)
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.current_user = self.get_current_user()
         domain = self.getDomain()
         filePath = getFilePath(domain)
@@ -2706,115 +2663,112 @@ class RootHandler(BaseHandler):
                 # no user provied, just return 401 response
                 return
             raise e  # re-throw the exception
-            
+
         root_uuid = response['root']
-        
-                
+
+
         filePath = getFilePath(domain)
-        log.info("filepath: " + filePath)
+        logger.info("filepath: " + filePath)
         verifyFile(filePath)
-        
-        
-        self.set_header('Content-Type', 'application/json') 
-        self.write(json_encode(response)) 
-        
-    def put(self): 
-        log = logging.getLogger("h5serv")
-        log.info('RootHandler.put ' + self.request.host)  
-        log.info('remote_ip: ' + self.request.remote_ip)
+
+
+        self.set_header('Content-Type', 'application/json')
+        self.write(json_encode(response))
+
+    def put(self):
+        logger.info('RootHandler.put ' + self.request.host)
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.current_user = self.get_current_user()
-        
+
         domain = self.getDomain()
         filePath = getFilePath(domain)
-        log.info("put filePath: " + filePath)
+        logger.info("put filePath: " + filePath)
         if op.isfile(filePath):
             msg = "Conflict: resource exists"
-            log.info(msg)    
+            logger.info(msg)
             raise HTTPError(409, reason=msg)  # Conflict - is this the correct code?
         if isTocFilePath(filePath):
             msg = "Forbidden: invalid resource"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(403, reason=msg)  # Forbidden - TOC file
         # create directories as needed
         makeDirs(op.dirname(filePath))
-        log.info("creating file: [" + filePath + "]")
-        
+        logger.info("creating file: [" + filePath + "]")
+
         try:
             Hdf5db.createHDF5File(filePath)
         except IOError as e:
-            log.info("IOError creating new HDF5 file: " + str(e.errno) + " " + e.strerror)
-            raise HTTPError(500, "Unexpected error: unable to create collection") 
-            
+            logger.info("IOError creating new HDF5 file: " + str(e.errno) + " " + e.strerror)
+            raise HTTPError(500, "Unexpected error: unable to create collection")
+
         response = self.getRootResponse(filePath)
-        
+
         self.addTocEntry(domain, filePath)
-          
+
         self.set_header('Content-Type', 'application/json')
         self.write(json_encode(response))
         self.set_status(201)  # resource created
-          
-    def delete(self): 
-        log = logging.getLogger("h5serv")
-        log.info('RootHandler.delete ' + self.request.host)  
-        log.info('remote_ip: ' + self.request.remote_ip) 
+
+    def delete(self):
+        logger.info('RootHandler.delete ' + self.request.host)
+        logger.info('remote_ip: ' + self.request.remote_ip)
         self.get_current_user()
-        
+
         domain = self.getDomain()
         filePath = getFilePath(domain)
-        log.info("delete filePath: " + filePath)
+        logger.info("delete filePath: " + filePath)
         verifyFile(filePath, True)
-        
+
         if not op.isfile(filePath):
             # file not there
             msg = "Not found: resource does not exist"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(404, reason=msg)  # Not found
-             
+
         if not os.access(filePath, os.W_OK):
             # file is read-only
             msg = "Forbidden: Resource is read-only"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(403, reason=msg) # Forbidden
-            
+
         if isTocFilePath(filePath):
             msg = "Forbidden: Resource is read-only"
-            log.info(msg)
+            logger.info(msg)
             raise HTTPError(403, reason=msg)  # Forbidden - TOC file
-            
+
         try:
             with Hdf5db(filePath, app_logger=log) as db:
                 rootUUID = db.getUUIDByPath('/')
                 acl = db.getAcl(rootUUID, self.userid)
-                self.verifyAcl(acl, 'delete')  # throws exception is unauthorized            
-        except IOError as e:         
-            log.info("IOError: " + str(e.errno) + " " + e.strerror)
+                self.verifyAcl(acl, 'delete')  # throws exception is unauthorized
+        except IOError as e:
+            logger.info("IOError: " + str(e.errno) + " " + e.strerror)
             status = errNoToHttpStatus(e.errno)
-            raise HTTPError(status, reason=e.strerror) 
-        
+            raise HTTPError(status, reason=e.strerror)
+
         try:
             self.removeTocEntry(domain, filePath)
         except IOError as ioe:
             # This exception may happen if the file has been imported directly
             # after toc creation
-            log.warn("IOError removing toc entry")
-            
-        try:  
-            os.remove(filePath)  
+            logger.warn("IOError removing toc entry")
+
+        try:
+            os.remove(filePath)
         except IOError as ioe:
-            log.info("IOError deleting HDF5 file: " + str(ioe.errno) + " " + ioe.strerror)
-            raise HTTPError(500, "Unexpected error: unable to delete collection") 
-         
-        
-        
-        
-              
+            logger.info("IOError deleting HDF5 file: " + str(ioe.errno) + " " + ioe.strerror)
+            raise HTTPError(500, "Unexpected error: unable to delete collection")
+
+
+
+
+
 class InfoHandler(RequestHandler):
-     
+
     def get(self):
-        log = logging.getLogger("h5serv")
-        log.info('InfoHandler.get ' + self.request.host)
-        log.info('remote_ip: ' + self.request.remote_ip)
-        
+        logger.info('InfoHandler.get ' + self.request.host)
+        logger.info('remote_ip: ' + self.request.remote_ip)
+
         greeting = "Welcome to h5serv!"
         about = "h5serv is a webservice for HDF5 data"
         doc_href = "http://h5serv.readthedocs.org"
@@ -2825,7 +2779,7 @@ class InfoHandler(RequestHandler):
         response['about'] = about
         response['documentation'] = doc_href
         response['h5serv_version'] = h5serv_version
-         
+
         accept_type = ''
         if 'accept' in self.request.headers:
             accept= self.request.headers['accept']
@@ -2834,8 +2788,8 @@ class InfoHandler(RequestHandler):
             accept_types = accept_values[0].split(';')
             accept_type = accept_types[0]
             # print 'accept_type:', accept_type
-        if accept_type == 'text/html':   
-            self.set_header('Content-Type', 'text/html') 
+        if accept_type == 'text/html':
+            self.set_header('Content-Type', 'text/html')
             htmlText = "<html><body><h1>" + response['greeting'] + "</h1>"
             htmlText += "<h2>" + response['about'] + "</h2>"
             htmlText += "<h2>Documentation: <a href=" + response['documentation'] +  "> h5serv documentation </a></h2>"
@@ -2845,35 +2799,33 @@ class InfoHandler(RequestHandler):
             htmlText += "</body></html>"
             self.write(htmlText)
         else:
-            self.set_header('Content-Type', 'application/json') 
-            self.write(json_encode(response)) 
-        
-        
+            self.set_header('Content-Type', 'application/json')
+            self.write(json_encode(response))
+
+
 def sig_handler(sig, frame):
-    log = logging.getLogger("h5serv")
-    log.warning('Caught signal: %s', sig)
+    logger.warning('Caught signal: %s', sig)
     IOLoop.instance().add_callback(shutdown)
- 
+
 def shutdown():
-    log = logging.getLogger("h5serv")
     MAX_WAIT_SECONDS_BEFORE_SHUTDOWN = 2
-    log.info('Stopping http server')
- 
-    log.info('Will shutdown in %s seconds ...', MAX_WAIT_SECONDS_BEFORE_SHUTDOWN)
+    logger.info('Stopping http server')
+
+    logger.info('Will shutdown in %s seconds ...', MAX_WAIT_SECONDS_BEFORE_SHUTDOWN)
     io_loop = tornado.ioloop.IOLoop.instance()
- 
+
     deadline = time.time() + MAX_WAIT_SECONDS_BEFORE_SHUTDOWN
- 
+
     def stop_loop():
         now = time.time()
         if now < deadline and (io_loop._callbacks or io_loop._timeouts):
             io_loop.add_timeout(now + 1, stop_loop)
         else:
             io_loop.stop()
-            log.info('Shutdown')
-    stop_loop() 
-    
-    log.info("closing db")
+            logger.info('Shutdown')
+    stop_loop()
+
+    logger.info("closing db")
 
 def make_app():
     static_url =  config.get('static_url')
@@ -2886,13 +2838,13 @@ def make_app():
         # "xsrf_cookies": True,
         "debug": config.get('debug')
     }
-       
-    favicon_path = "favicon.ico" 
+
+    favicon_path = "favicon.ico"
     print "dirname path:", os.path.dirname(__file__)
     print "favicon_path:", favicon_path
     print 'Static content in the path:' + static_path + " will be displayed via the url: " + static_url
     print 'isdebug:', settings['debug']
-    
+
     app = Application( [
         url(r"/datasets/.*/type", DatatypeHandler),
         url(r"/datasets/.*/shape", ShapeHandler),
@@ -2918,8 +2870,8 @@ def make_app():
         url(r"/groups/.*/links/.*", LinkHandler),
         url(r"/groups/.*/links\?.*", LinkCollectionHandler),
         url(r"/groups/.*/links", LinkCollectionHandler),
-        url(r"/groups/", GroupHandler), 
-        url(r"/groups/.*", GroupHandler), 
+        url(r"/groups/", GroupHandler),
+        url(r"/groups/.*", GroupHandler),
         url(r"/groups\?.*", GroupCollectionHandler),
         url(r"/groups", GroupCollectionHandler),
         url(r"/info", InfoHandler),
@@ -2934,37 +2886,36 @@ def make_app():
 
 def main():
     # os.chdir(config.get('datapath'))
-    
+
     # create logger
-    log = logging.getLogger("h5serv")
-    log.setLevel(logging.INFO)
+    logger.setLevel(logging.INFO)
     # set daily rotating log
     handler = logging.handlers.TimedRotatingFileHandler('../log/h5serv.log',
                                        when="midnight",
                                        interval=1,
                                        backupCount=0,
                                        utc=True)
-    
+
     # create formatter
     formatter = logging.Formatter("%(asctime)s:%(levelname)s:%(filename)s:%(lineno)d::%(message)s")
     # add formatter to handler
     handler.setFormatter(formatter)
     # add handler to logger
-    log.addHandler(handler)
+    logger.addHandler(handler)
     port = int(config.get('port'))
     global server
     app = make_app()
     server = tornado.httpserver.HTTPServer(app)
     server.listen(port)
     msg = "Starting event loop on port: " + str(port)
-    
+
     ssl_cert = config.get('ssl_cert')
     print "ssl_cert:", ssl_cert
     ssl_key = config.get('ssl_key')
     print "ssl_key:", ssl_key
     ssl_port = config.get('ssl_port')
     print "ssl_port:", ssl_port
-     
+
     if ssl_cert and op.isfile(ssl_cert) and ssl_key and op.isfile(ssl_key) and ssl_port:
         ssl_cert_pwd = config.get('ssl_cert_pwd')
         ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
@@ -2972,13 +2923,13 @@ def main():
         ssl_server = tornado.httpserver.HTTPServer(app, ssl_options=ssl_ctx)
         ssl_server.listen(ssl_port)
         msg += " and port: " + str(ssl_port) + " (SSL)"
-        
+
     signal.signal(signal.SIGTERM, sig_handler)
     signal.signal(signal.SIGINT, sig_handler)
-    log.info("INITIALIZING...")
-    log.info(msg)
+    logger.info("INITIALIZING...")
+    logger.info(msg)
     print msg
- 
+
     IOLoop.current().start()
 
 main()

--- a/server/fileUtil.py
+++ b/server/fileUtil.py
@@ -20,12 +20,12 @@ from tocUtil import getTocFilePath
 """
  File util helper functions
  (primarily from mapping files to domains and vice-versa)
-""" 
+"""
 
 def getFileModCreateTimes(filePath):
     (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime) = os.stat(filePath)
     return (mtime, ctime)
-    
+
 def isIPAddress(s):
     """Return True if the string looks like an IP address:
         n.n.n.n where n is between 0 and 255 """
@@ -40,42 +40,41 @@ def isIPAddress(s):
         except ValueError:
             return False
     return True
-        
+
 
 def getFilePath(host_value):
-    # logging.info('getFilePath[' + host_value + ']')
     #strip off port specifier (if present)
     npos = host_value.rfind(':')
     if npos > 0:
         host = host_value[:npos]
     else:
         host = host_value
-    
+
     topdomain = config.get('domain')
-    
-    #check to see if this is an ip address 
+
+    #check to see if this is an ip address
     if isIPAddress(host):
         host = topdomain  # use topdomain
-       
+
     if host.lower() == topdomain:
         # if host is the same as topdomain, return toc path
         filePath = getTocFilePath()
-        return filePath   
-     
+        return filePath
+
     if len(host) <= len(topdomain) or host[-len(topdomain):].lower() != topdomain:
         raise HTTPError(403, message='top-level domain is not valid')
-        
-      
+
+
     if host[-(len(topdomain) + 1)] != '.':
         # there needs to be a dot separator
         raise HTTPError(400, message='domain name is not valid')
-    
+
     host = host[:-(len(topdomain)+1)]   # strip off top domain part
-    
+
     if len(host) == 0 or host[0] == '.':
         # needs a least one character (which can't be '.')
         raise HTTPError(400, message='domain name is not valid')
-        
+
     filePath = config.get('datapath')
     while len(host) > 0:
         if len(filePath) > 0 and filePath[len(filePath) - 1] != '/':
@@ -86,17 +85,15 @@ def getFilePath(host_value):
             host = ''
         elif npos == 0 or npos == len(host) - 1:
             raise HTTPError(400) # Bad syntax
-        else:     
+        else:
             filePath += host[(npos+1):]
             host = host[:npos]
 
     filePath += ".h5"   # add extension
-    
-    # logging.info('getFilePath[' + host + '] -> "' + filePath + '"')
-    
+
     return filePath
-        
-    
+
+
 def getDomain(filePath):
     # Get domain given a file path
     if filePath.endswith(".h5"):
@@ -112,18 +109,16 @@ def getDomain(filePath):
         dirname = op.dirname(dirname)
     domain += '.'
     domain += config.get('domain')
-      
-    return domain 
-  
+
+    return domain
+
 
 def verifyFile(filePath, writable=False):
     if not op.isfile(filePath):
         raise HTTPError(404)  # not found
     if not is_hdf5(filePath):
-        # logging.warning('this is not a hdf5 file!')
         raise HTTPError(404)
     if writable and not os.access(filePath, os.W_OK):
-        # logging.warning('attempting update of read-only file')
         print "attempting to update read-only file"
         raise HTTPError(403)
 
@@ -131,12 +126,9 @@ def makeDirs(filePath):
     # Make any directories along path as needed
     if len(filePath) == 0 or op.isdir(filePath):
         return
-    # logging.info('makeDirs filePath: [' + filePath + ']')
     dirname = op.dirname(filePath)
-    
+
     if len(dirname) >= len(filePath):
-        #logging.warning('makeDirs - unexpected dirname')
         return
     makeDirs(dirname)  # recursive call
-    #logging.info('mkdir("' + filePath + '")')
-    os.mkdir(filePath)  # should succeed since parent directory is created  
+    os.mkdir(filePath)  # should succeed since parent directory is created

--- a/server/tocUtil.py
+++ b/server/tocUtil.py
@@ -21,7 +21,10 @@ import fileUtil
 """
  TOC (Table of contents) util helper functions
  Creates a directory listing in the form of an HDF5 file
-""" 
+"""
+
+logger = logging.getLogger('h5serv')
+
 
 def getTocFilePath():
     datapath = config.get('datapath')
@@ -29,21 +32,20 @@ def getTocFilePath():
     if not op.exists(toc_file_path):
         createTocFile(datapath)
     return toc_file_path
-    
+
+
 def isTocFilePath(filePath):
-    log = logging.getLogger("h5serv")
     datapath = config.get('datapath')
     toc_file_path = op.join(datapath, config.get('toc_name'))
     if filePath == toc_file_path:
         isTocFilePath = True
     else:
         isTocFilePath = False
-    #log.info("isTocFilePath(" + filePath + ") ->" + str(isTocFilePath))
     return isTocFilePath
 
+
 def createTocFile(dir_path):
-    log = logging.getLogger("h5serv")
-    log.info("createTocFile(" + dir_path + ")") 
+    logger.info("createTocFile(" + dir_path + ")")
     hdf5_ext = config.get('hdf5_ext')
     if not op.exists(dir_path):
         raise IOError("invalid path")
@@ -65,17 +67,14 @@ def createTocFile(dir_path):
             file_name = file_name[:-3]
             if h5py.is_hdf5(file_path):
                 if not grp:
-                    log.info("createTocFile - create_group: " + grp_path)
+                    logger.info("createTocFile - create_group: " + grp_path)
                     grp = f.create_group(grp_path)
                 domain_path = fileUtil.getDomain(file_path)
                 #verify that we can convert the domain back to a file path
                 try:
                     fileUtil.getFilePath(domain_path)
                     # ok - add the external link
-                    log.info("createTocFile - ExternalLink: " + domain_path)
+                    logger.info("createTocFile - ExternalLink: " + domain_path)
                     grp[file_name] = h5py.ExternalLink(domain_path, "/")
                 except HTTPError:
-                    log.info("file path: [" + file_path + "] is not valid dns name, ignoring")
-        
-    
-  
+                    logger.info("file path: [" + file_path + "] is not valid dns name, ignoring")


### PR DESCRIPTION
This removes a lot of tedious calls to `logging.getLogger` in the server code and conforms more to the practice of using module-level loggers recommended by the [documentation](https://docs.python.org/3/library/logging.html#logger-objects).

Thanks for this great project!