### PR TITLE
Added BaseHandler.options() for web-browser POST.

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -276,7 +276,8 @@ class BaseHandler(tornado.web.RequestHandler):
         else:
             return "json"
             
-
+    def options(self):
+        self.set_header('Access-Control-Allow-Headers', 'Content-type,')
 
 class LinkCollectionHandler(BaseHandler):
     def get(self):


### PR DESCRIPTION
I'm a bit lost in the differences between master/develop branch, but if I have this right then the fix I suggested in the issues post for allowing browser POST is not included here yet.

These two lines should enable POST from the web-browser, otherwise 405 method not defined was returned for 'options' preflight request from the browser.