### PR TITLE
Tornado has changed internal callback API

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -3131,7 +3131,7 @@ def shutdown():
 
     def stop_loop():
         now = time.time()
-        if now < deadline and (io_loop._callbacks or io_loop._timeouts):
+        if now < deadline:
             io_loop.add_timeout(now + 1, stop_loop)
         else:
             io_loop.stop()


### PR DESCRIPTION
Tornado 5.1 (at least) no longer has a "_callbacks" attribute. Without this change, the server won't shut down, and one must first suspend the process and then "kill -9" it.